### PR TITLE
Docs live somewhere else now

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ We have a tool called [Prune](https://github.com/ComplianceAsCode/auditree-prune
 [pre-commit-config]: https://github.com/ComplianceAsCode/auditree-framework/blob/master/.pre-commit-config.yaml
 [python-badge]: https://img.shields.io/badge/python-v3.6+-blue.svg
 [python]: https://www.python.org/downloads/
-[quick start guide]: https://github.com/ComplianceAsCode/auditree-framework/blob/master/doc/quick-start.rst
+[quick start guide]: https://github.com/ComplianceAsCode/auditree-framework/blob/master/doc-source/quick-start.rst
 [yapf]: https://github.com/google/yapf
 [lint-test]: https://github.com/ComplianceAsCode/auditree-framework/actions?query=workflow%3A%22Test+python+code+%26+lint%22
 [pypi-upload]: https://github.com/ComplianceAsCode/auditree-framework/actions?query=workflow%3A%22Upload+Python+Package%22


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What
Link needed updating as doc source has moved.

## Why
So people can find the right page, not a 404

## How
Correct the link doc->doc-source

## Test
Verified link.

## Context

_Provide a bulleted list of GitHub issues, or any other references (mailing list discussion, etc...) that reviewers can reference
for additional information regarding scope of the pull request._
