### PR TITLE
Add external evidence to evidence map

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.0.1
+
+- [FIXED] Added external evidence as a valid evidence type to evidence map.
+
 # 1.0.0
 
-[NEW] Make the Auditree Framework public.
+- [NEW] Make the Auditree Framework public.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -478,7 +478,8 @@ __init_map = {
     'tmp': TmpEvidence,
     'reports': ReportEvidence,
     'derived': DerivedEvidence,
-    'raw': RawEvidence
+    'raw': RawEvidence,
+    'external': ExternalEvidence
 }
 
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add external evidence to evidence map

## Why

So the Locker can process External evidence via plant and prune

## How

Add external evidence to evidence map

## Test

Bug found in prune and resolution tested with `prune` and things work now

## Context

Closes #5 
