### PR TITLE
Fix python publish workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -23,6 +23,8 @@ jobs:
         make develop
     - name: Test & lint
       run: |
+        git config --global user.email "you@example.com"
+        git config --global user.name "A. Name"
         make code-lint
         make test
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix python publish workflow

## Why

So tests can run successfully and we can publish to PyPI as part of a release

## How

Add `git config` settings in order to allow for locker "unit" tests to run successfully in GH Actions

## Test

_Should work?  We'll see...

## Context

N/A
