### PR TITLE
Fix workflow badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,5 +147,5 @@ We have a tool called [Plant](https://github.com/ComplianceAsCode/auditree-plant
 [python]: https://www.python.org/downloads/
 [quick start guide]: https://github.com/ComplianceAsCode/auditree-framework/blob/master/doc-source/quick-start.rst
 [yapf]: https://github.com/google/yapf
-[lint-test]: https://github.com/ComplianceAsCode/auditree-framework/actions?query=workflow%3A%22Test+python+code+%26+lint%22
-[pypi-upload]: https://github.com/ComplianceAsCode/auditree-framework/actions?query=workflow%3A%22Upload+Python+Package%22
+[lint-test]: https://github.com/ComplianceAsCode/auditree-framework/actions?query=workflow%3A%22format+%7C+lint+%7C+test%22
+[pypi-upload]: https://github.com/ComplianceAsCode/auditree-framework/actions?query=workflow%3A%22PyPI+upload%22


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix workflow badge links

## Why

So the links from the badges in the readme work correctly

## How

Fix workflow badge links

## Test

Works now

## Context

N/A
