### PR TITLE
Resolve missing PyYAML package dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.0.2
+
+- [FIXED] Added PyYAML library as a dependency to resolve Github service issue.
+
 # 1.0.1
 
 - [FIXED] Added external evidence as a valid evidence type to evidence map.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     ibm-cloud-security-advisor-findingsapi-sdk>=2.0.5
     deprecated>=1.2.9
     ilcli>=0.3.1
+    PyYAML>=5.3.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Resolve missing PyYAML module dependency

## Why

The Github service needs PyYAML to do its thing.

## How

Add PyYAML to the setup.cfg

## Test

fetchers, checks, and notifiers all fire as expected

## Context

Fixes #9 
