### PR TITLE
Add branch option to GH service for commit detail retrieval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+- [NEW] Added branch option to retrieving commit details from the Github service.
+
 # 1.1.0
 
 - [NEW] Added repository details retrieval to Github service class.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/compliance/utils/services/github.py
+++ b/compliance/utils/services/github.py
@@ -497,14 +497,15 @@ class Github(object):
         )
         return self._make_request('get', f'repos/{repo}')
 
-    def get_commit_details(self, repo, since):
+    def get_commit_details(self, repo, since, branch='master'):
         """
         Retrieve a repository's commit details since a given date/time.
 
         :param repo: the organization/repository as a string.
         :param since: the starting date/time as a datetime.
+        :param branch: the branch as a string.  Defaults to master.
 
-        :returns: the repository's commit details since a given date/time.
+        :returns: the repo branch's commit details since a given date/time.
         """
         self.session.headers.update(
             {'Accept': 'application/vnd.github.v3+json'}
@@ -512,7 +513,9 @@ class Github(object):
         return self._make_request(
             'get',
             f'repos/{repo}/commits',
-            params={'since': since.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            params={
+                'since': since.strftime('%Y-%m-%dT%H:%M:%SZ'), 'sha': branch
+            }
         )
 
     def get_branch_protection_details(self, repo, branch='master'):


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add branch option to GH service for commit detail retrieval.

## Why

So that downstream logic can specify different branches to retrieve commit details for.

## How

Add branch option to GH service for commit detail retrieval.

## Test

Runs in venv

## Context

In support of #19 
