### PR TITLE
Fix msg_ method calculation in notifiers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.1
+
+- [FIXED] Notifier `msg_` methods are now accurately found based on check `test_` method names.
+
 # 1.2.0
 
 - [NEW] Added branch option to retrieving commit details from the Github service.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'

--- a/compliance/notify.py
+++ b/compliance/notify.py
@@ -62,7 +62,7 @@ class _BaseNotifier(object):
 
             msg_method = 'get_notification_message'
             if len(test_obj.tests) > 1:
-                candidate = method_name.replace('test_', 'msg_')
+                candidate = method_name.replace('test_', 'msg_', 1)
                 if hasattr(test_obj, candidate):
                     msg_method = candidate
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix msg_ method calculation in notifiers.

If a test method is called test_mytest_method() and there is a msg_mytest_method() for it, the current implementation will not find it as test_ is completely into method name expecting msg_mymsg_method() which is incorrect.

This fixes this issue.

## Why

We need to ensure that for each `test_` method in a check an accompanying `msg_` notifier method can be found by the framework.

## How

Ensure that only the prefix `test_` is replaced with `msg_` in the notifier based class logic.

## Test

Works like a champ

## Context

N/A
