### PR TITLE
Update GH service helper method to include commit sig content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.2
+
+- [FIXED] Github service branch protection method now returns "required_signatures" content.
+
 # 1.2.1
 
 - [FIXED] Notifier `msg_` methods are now accurately found based on check `test_` method names.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/compliance/utils/services/github.py
+++ b/compliance/utils/services/github.py
@@ -528,7 +528,7 @@ class Github(object):
         :returns: the repository branch's branch protection details.
         """
         self.session.headers.update(
-            {'Accept': 'application/vnd.github.luke-cage-preview+json'}
+            {'Accept': 'application/vnd.github.zzzax-preview+json'}
         )
         return self._make_request(
             'get', f'repos/{repo}/branches/{branch}/protection'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Include required_signatures in GH service branch protection method response.

## Why

We want all of the branch protection content returned from the GH service branch protection helper method including whether commits require verified signatures.

## How

Apply preview header to the GH API call that will include `required_signatures` content in the response.

## Test

Works like a champ

## Context

In support of https://github.com/ComplianceAsCode/auditree-arboretum/issues/13
