### PR TITLE
Add path option to GH service get_commit_details

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.3
+
+- [IMPROVED] Github service `get_commit_details` now take `path` as an optional argument.
+
 # 1.2.2
 
 - [FIXED] Github service branch protection method now returns "required_signatures" content.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.2.2'
+__version__ = '1.2.3'

--- a/compliance/utils/services/github.py
+++ b/compliance/utils/services/github.py
@@ -497,26 +497,24 @@ class Github(object):
         )
         return self._make_request('get', f'repos/{repo}')
 
-    def get_commit_details(self, repo, since, branch='master'):
+    def get_commit_details(self, repo, since, branch='master', path=None):
         """
-        Retrieve a repository's commit details since a given date/time.
+        Retrieve a repository branch's commit details since a given date/time.
 
         :param repo: the organization/repository as a string.
         :param since: the starting date/time as a datetime.
         :param branch: the branch as a string.  Defaults to master.
+        :param path: if provided, only commits for the path will be returned.
 
         :returns: the repo branch's commit details since a given date/time.
         """
         self.session.headers.update(
             {'Accept': 'application/vnd.github.v3+json'}
         )
-        return self._make_request(
-            'get',
-            f'repos/{repo}/commits',
-            params={
-                'since': since.strftime('%Y-%m-%dT%H:%M:%SZ'), 'sha': branch
-            }
-        )
+        opts = {'since': since.strftime('%Y-%m-%dT%H:%M:%SZ'), 'sha': branch}
+        if path:
+            opts['path'] = path
+        return self._make_request('get', f'repos/{repo}/commits', params=opts)
 
     def get_branch_protection_details(self, repo, branch='master'):
         """


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add path option to GH service get_commit_details

## Why

So we can get get commit details for a specific file/filepath.  In support of https://github.com/ComplianceAsCode/auditree-arboretum/issues/18.

## How

Add path as an optional argument on the GH service method `get_commit_details`.  If supplied, pass the `path` as a parameter to the request to the GH API.

## Test

works

## Context

In support of https://github.com/ComplianceAsCode/auditree-arboretum/issues/18
