### PR TITLE
Add failed to load error logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.4
+
+- [IMPROVED] Fetchers and checks that failed to load appear as errors in STDERR now.
+
 # 1.2.3
 
 - [IMPROVED] Github service `get_commit_details` now take `path` as an optional argument.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.2.3'
+__version__ = '1.2.4'

--- a/compliance/controls.py
+++ b/compliance/controls.py
@@ -18,6 +18,7 @@ import copy
 import itertools
 import json
 import os
+from collections import defaultdict
 
 
 class ControlDescriptor(object):
@@ -48,6 +49,18 @@ class ControlDescriptor(object):
     def as_dict(self):
         """Provide control descriptor content as a modifiable dictionary."""
         return copy.deepcopy(self._controls)
+
+    @property
+    def accred_checks(self):
+        """Provide all checks by accreditation (key) as a dictionary."""
+        if not hasattr(self, '_accred_checks'):
+            self._accred_checks = defaultdict(list)
+            for check, evidence in self._controls.items():
+                for control in evidence.values():
+                    for accreds in control.values():
+                        for accred in accreds:
+                            self._accred_checks[accred].append(check)
+        return self._accred_checks
 
     def get_accreditations(self, test_path):
         """

--- a/compliance/scripts/compliance_cli.py
+++ b/compliance/scripts/compliance_cli.py
@@ -157,11 +157,15 @@ class ComplianceCLI(Command):
                         '\nUnable to resolve dependency issues with %s.\n',
                         ', '.join(reruns)
                     )
+                for fetch_load_error in fetch.load_errors:
+                    self.err(f'\nERROR: {fetch_load_error}\n')
         if args.check:
             with CheckMode(args, self.extra_args) as check:
                 accreds = ', '.join(check.accreds)
-                self.out(f'\nCheck Run - Accreditations: {accreds} \n')
+                self.out(f'\nCheck Run - Accreditations: {accreds}\n')
                 success = check.run_checks() and success
+                for check_load_error in check.load_errors:
+                    self.err(f'\nERROR: {check_load_error}\n')
         return 0 if success else 1
 
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add failed to load error logging for fetchers and checks that failed to load.

## Why

This provides feedback when the unittest.TestLoader was unable to load a fetchers or a check so that the user can triage the problem rather than hiding the problem as is the current behavior.

## How

- Display all relevant loader errors
- Compare checks that were requested for execution and those tests that were found by the loader and report on those requested but not found by the loader.

## Test

- For fetchers:
   - When a fetcher fails to load the error content is displayed.  
   - All other behavior is as before.
- For checks:
   - When a check fails to load the error content is displayed.  
   - When a check was requested for execution but not found then an appropriate error message is displayed.
   - All other behavior is as before.

## Context

Closes #13 
