### PR TITLE
Fix credentials section bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.5
+
+- [FIXED] Credentials section bug affecting the Slack notifier.
+
 # 1.2.4
 
 - [IMPROVED] Fetchers and checks that failed to load appear as errors in STDERR now.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.2.4'
+__version__ = '1.2.5'

--- a/compliance/utils/credentials.py
+++ b/compliance/utils/credentials.py
@@ -81,8 +81,9 @@ class Config():
             logger.debug(
                 f'Loading credentials from ENV vars: {", ".join(env_vars)}'
             )
-
-        params = self._cfg.options(section)
+        params = []
+        if self._cfg.has_section(section):
+            params = self._cfg.options(section)
         values = [self._cfg.get(section, x) for x in params]
 
         d = OrderedDict(zip(params, values))


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix credentials section bug.

## Why

So when sections aren't found in the credentials, the Slack notifier can continue to step through its process of searching for creds.

## How

- Add if logic to check for a section rather than assume that it exists.

## Test

Flows correctly now

## Context

Fixes #29 
