### PR TITLE
ComplianceFetcher.session is resettable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
+# 1.2.6
+
+- [FIXED] ComplianceFetcher.session can now be reset.
+
 # 1.2.5
 
-- [FIXED] Credentials section bug affecting the Slack notifier.
+- [FIXED] Credentials section bug affecting the Slack notifier is squashed.
 
 # 1.2.4
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ There are some guidelines to follow when making a common fetcher or check:
 
   - The sub-document structure to adhere to for a common module is one where the root of the sub-document is the org. Under the org there should be a name field which would refer to the organization’s name. Each common module configuration sub-document should also be under the org sub-document. For example:
 
-```json
+```
         {
            ...
            "org": {

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.2.5'
+__version__ = '1.2.6'

--- a/compliance/fetch.py
+++ b/compliance/fetch.py
@@ -35,12 +35,17 @@ class ComplianceFetcher(unittest.TestCase):
         """
         Provide a requests session object with User-Agent header.
 
-        :param url: optional base URL for the session requests to use.
+        :param url: optional base URL for the session requests to use.  A url
+          argument triggers a new session object to be created whereas no url
+          argument will return the current session object if one exists.
         :param creds: optional authentication credentials.
         :param headers: optional kwargs to add to session headers.
 
         :returns: a requests Session object.
         """
+        if url is not None and hasattr(cls, '_session'):
+            cls._session.close()
+            delattr(cls, '_session')
         if not hasattr(cls, '_session'):
             if url:
                 cls._session = BaseSession(url)


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

All for the fetcher session object to be reset.

## Why

So that it can be used with multiple base URLs per fetcher.

## How

If a `url` is passed as a parameter then ComplianceFetcher.session() will recycle the old session object and create a new one.  When no `url` is provided the existing session object is passed back for continued use.

## Test

works

## Context

Fixes #52 and in support of https://github.com/ComplianceAsCode/auditree-arboretum/pull/15
