### PR TITLE
Remove PyYAML dependency

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# 1.2.7
+
+- [CHANGED] Removed PyYAML dependency to resolve downstream dependency issues.
+- [CHANGED] Removed Github.get_issue_template helper method.
+
 # 1.2.6
 
 - [FIXED] ComplianceFetcher.session can now be reset.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.2.6'
+__version__ = '1.2.7'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,6 @@ install_requires =
     ibm-cloud-security-advisor-findingsapi-sdk>=2.0.5
     deprecated>=1.2.9
     ilcli>=0.3.1
-    PyYAML>=5.3.1
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Remove PyYAML

## Why

The functionality it supports is not necessary and was a holdover from when the GH service was copied from utilitarian.

## How

- Remove dependency
- Remove the Github service get_issue_template method.

## Test

works

## Context

Closes #60 
