### PR TITLE
Simplify controls.json format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
-# UNRELEASED
+# 1.3.0
 
+- [IMPROVED] Simplified `controls.json` format.  Original format is also supported.
+- [NEW] Added documentation for `controls.json` and check execution.
+- [NEW] Added ControlDescriptor unit tests.
 - [FIXED] ComplianceFetcher session object is auto-closed now in tearDownClass.
 
 # 1.2.7

--- a/doc-source/design-principles.rst
+++ b/doc-source/design-principles.rst
@@ -22,6 +22,7 @@ The tool is divided in two main parts:
 Both fetch and check phases are run by unittest. This is very convenient
 as fetchers and checks are loaded automatically by ``unittest``.
 
+
 Evidences
 ~~~~~~~~~
 
@@ -145,7 +146,7 @@ This is a list of modifications that are completely forbidden:
 * Adding live-generated data that does not come from the source.
 
 * Applying `check-like` logic (e.g. your data update if it includes an
-  `if`). Checkers should test the evidence, not fetchers.
+  `if`). Checks should test the evidence, not fetchers.
 
 Evidence Validation
 ===================
@@ -231,6 +232,13 @@ due to an unavailable evidence dependency.
       ...
       return json.dumps(foo_bar_data)
 
+Fetcher Execution
+=================
+
+The Auditree framework will run all fetchers (tests prefixed by ``fetch_``)
+that it can find.
+
+
 Compliance Checks
 ~~~~~~~~~~~~~~~~~
 
@@ -242,8 +250,8 @@ provided on the command line.
 Checks *assume* that all evidence is retrieved by fetchers.  Consequently
 checks **should not** be used to retrieve or store any ``RawEvidence`` in the
 evidence locker. Each check class may have from one to multiple checks defined
-(that is, a check is a method prefixed with `test_` in a check class). Each of
-these checks will be executed by the compliance tool with the following
+(that is, a check is a method prefixed with ``test_`` in a check class). Each of
+these checks will be executed by the Auditree framework with the following
 possible results:
 
 * ``OK``: the check ran successfully and **passed** all validations.
@@ -359,12 +367,34 @@ prior to executing the check's logic.
               self.add_warnings('bar stuff', warnings)
               self.add_successes('bar stuff', successes)
 
+Check Execution
+===============
+
+The Auditree framework executes checks (tests prefixed by ``test_``) based
+on accreditation groupings defined in a ``controls.json`` config file.
+This is especially useful when targeting check result content to the
+appropriate groups of people.  The framework will by default look for
+``controls.json`` in the current directory.  It is possible to supply the
+framework with alternate ``controls.json`` location(s) by providing an
+alternate path or paths at the end of a compliance check execution command via
+the CLI.  In the case of multiple locations, the framework will combine the
+content of all ``controls.json`` files found together.  With this check to
+accreditation mapping, the framework can execute checks based on the
+accreditations passed to the framework by the CLI.
+
+``controls.json`` content format example::
+
+  {
+    "chk_pkg.chk_cat_foo.checks.chk_module_foo.FooCheckClass": ["accred.one"],
+    "chk_pkg.chk_cat_bar.checks.chk_module_bar.BarCheckClass": ["accred.one", "accred.two"]
+  }
+
 
 Fixers
 ~~~~~~
 
 After checks have been run, but before notifications or reports are
-generated, the compliance tool will optionally try to fix the
+generated, the Auditree framework will optionally try to fix the
 issues automatically. This is controlled with the ``--fix`` option.
 By default it is ``off``, and this is the mode that is used during the
 daily CI runs in Travis. But you can also set it to ``dry-run`` or ``on``.
@@ -378,6 +408,7 @@ listed in dry-run mode. If the fix succeeds, then a counter
 in the notification message.
 
 See :ref:`fixers` section for more information.
+
 
 Report Builder
 ~~~~~~~~~~~~~~
@@ -402,10 +433,11 @@ messages to stdout, etc).
 
 See :ref:`notifiers-description` section for more information.
 
+
 Execution Config
 ~~~~~~~~~~~~~~~~
 
-The compliance tool is designed to be run locally from your PC or from
+The Auditree framework is designed to be run locally from your PC or from
 a CI server like Jenkins or Travis. The execution can be tweaked at 2
 levels:
 
@@ -421,6 +453,7 @@ levels:
   example.
 
 .. _credentials:
+
 
 Credentials
 ~~~~~~~~~~~

--- a/doc-source/quick-start.rst
+++ b/doc-source/quick-start.rst
@@ -9,7 +9,7 @@ There might be some terms in this quick start that you don't fully
 understand, so you may want to have a look into
 :ref:`design-principles` section.
 
-The compliance tool requires, at least, one directory with the
+The Auditree framework requires, at least, one directory with the
 fetchers and checks. In order to learn how to use it, let's use a
 demo folder with a simple set of fetchers and checks. You can find it
 at `doc/demo-checks`::
@@ -59,7 +59,7 @@ mode::
 
   $ compliance --fetch --evidence no-push -C setup.json .
 
-The compliance tool will ``pull`` the repository to
+The Auditree framework will ``pull`` the repository to
 ``/tmp/compliance`` (only if it does not exist already), then run all
 the fetchers that need to be run (i.e. those whose evidence TTL
 has expired) but it will **not** push anything. This is handy for
@@ -97,10 +97,17 @@ instead::
 controls.json
 -------------
 
-The mapping between accreditations and checks happens at
-``controls.json``. New checks must be included here in order to be
-collected by the compliance tool. Note that this is not the same case
-as in fetchers, where all of them are executed.
+The mapping between a check (check class path) and accreditations
+(a list of accreditations) happens in the ``controls.json`` config
+file.  Each new check must be included in ``controls.json`` in
+order to be considered for execution by the Auditree framework.
+Note that this is not the case for fetchers, where all are executed.
+As an example, the format for ``controls.json`` is as follows::
+
+  {
+    "chk_pkg.chk_cat_foo.checks.chk_module_foo.FooCheckClass": ["accred.one"],
+    "chk_pkg.chk_cat_bar.checks.chk_module_bar.BarCheckClass": ["accred.one", "accred.two"]
+  }
 
 
 A few recommendations

--- a/doc-source/report-builder.rst
+++ b/doc-source/report-builder.rst
@@ -5,7 +5,7 @@
 Report Builder
 ==============
 
-After tests have been run by the compliance tool, the
+After tests have been run by the Auditree framework, the
 :py:class:`~compliance.report.ReportBuilder` is executed in order to
 render all the required reports. This is how it works:
 
@@ -43,7 +43,7 @@ render all the required reports. This is how it works:
    notify that the error occurred, in standard output. Note that report
    generation will not halt on an error, and will attempt to generate all other
    reports.
-   
+
 
 .. _templating:
 

--- a/doc-source/running-on-travis.rst
+++ b/doc-source/running-on-travis.rst
@@ -5,7 +5,7 @@
 Running on Travis
 =================
 
-Running compliance tool from a CI like Travis can be really useful for
+Running the Auditree framework from a CI like Travis can be really useful for
 executing your compliance checks periodically. Thus you can track the
 current level of compliance for different standards and also notify
 people whenever there is a failure, so it can be fixed in some way.

--- a/test/fixtures/controls/original/controls.json
+++ b/test/fixtures/controls/original/controls.json
@@ -1,0 +1,7 @@
+{
+  "foo_pkg.checks.test_foo_module.FooCheck": {
+    "foo_evidence": {
+      "foo_control": ["accred.foo"]
+    }
+  }
+}

--- a/test/fixtures/controls/simplified/controls.json
+++ b/test/fixtures/controls/simplified/controls.json
@@ -1,0 +1,1 @@
+{"bar_pkg.checks.test_bar_module.BarCheck": ["accred.bar"]}

--- a/test/t_compliance/t_controls/__init__.py
+++ b/test/t_compliance/t_controls/__init__.py
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Compliance automation package."""
-
-__version__ = '1.3.0'
+"""Compliance automation control descriptor tests module."""

--- a/test/t_compliance/t_controls/test_controls.py
+++ b/test/t_compliance/t_controls/test_controls.py
@@ -1,0 +1,116 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2020 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compliance automation control descriptor tests module."""
+
+import unittest
+
+from compliance.controls import ControlDescriptor
+
+
+class ControlDescriptorTest(unittest.TestCase):
+    """ControlDescriptor test class."""
+
+    def setUp(self):
+        """Initialize each test."""
+        cd_paths = [
+            './test/fixtures/controls/original',
+            './test/fixtures/controls/simplified',
+            './faker'
+        ]
+        self.cd = ControlDescriptor(cd_paths)
+        self.expected_foo_check = 'foo_pkg.checks.test_foo_module.FooCheck'
+        self.expected_bar_check = 'bar_pkg.checks.test_bar_module.BarCheck'
+
+    def test_contructor_and_base_properties(self):
+        """Check ControlDescriptor constructed as expected."""
+        self.assertEqual(len(self.cd.paths), 2)
+        expected_ends_with = [
+            '/test/fixtures/controls/original/controls.json',
+            '/test/fixtures/controls/simplified/controls.json'
+        ]
+        self.assertNotEqual(self.cd.paths[0], expected_ends_with[0])
+        self.assertTrue(self.cd.paths[0].endswith(expected_ends_with[0]))
+        self.assertNotEqual(self.cd.paths[1], expected_ends_with[1])
+        self.assertTrue(self.cd.paths[1].endswith(expected_ends_with[1]))
+        self.assertEqual(
+            self.cd.as_dict,
+            {
+                self.expected_foo_check: {
+                    'foo_evidence': {
+                        'foo_control': ['accred.foo']
+                    }
+                },
+                self.expected_bar_check: ['accred.bar']
+            }
+        )
+
+    def test_as_dict_immutability(self):
+        """Ensure that control content cannot be changed through as_dict."""
+        with self.assertRaises(AttributeError) as ar:
+            self.cd.as_dict = {'foo': 'bar'}
+        self.assertEqual(str(ar.exception), "can't set attribute")
+        controls_copy = self.cd.as_dict
+        self.assertEqual(controls_copy, self.cd.as_dict)
+        controls_copy.update({'foo': 'bar'})
+        self.assertNotEqual(controls_copy, self.cd.as_dict)
+
+    def test_accred_checks(self):
+        """Check that checks are organized by accreditations correctly."""
+        self.assertEqual(
+            self.cd.accred_checks,
+            {
+                'accred.foo': {self.expected_foo_check},
+                'accred.bar': {self.expected_bar_check}
+            }
+        )
+
+    def test_get_accreditations(self):
+        """Ensure the correct accreditations are returned based on check."""
+        self.assertEqual(
+            self.cd.get_accreditations(self.expected_foo_check),
+            {'accred.foo'}
+        )
+        self.assertEqual(
+            self.cd.get_accreditations(self.expected_bar_check),
+            {'accred.bar'}
+        )
+
+    def test_is_test_included(self):
+        """Test check is included in accreditations functionality."""
+        self.assertTrue(
+            self.cd.is_test_included(self.expected_foo_check, ['accred.foo'])
+        )
+        self.assertFalse(
+            self.cd.is_test_included(self.expected_foo_check, ['accred.bar'])
+        )
+        self.assertTrue(
+            self.cd.is_test_included(self.expected_bar_check, ['accred.bar'])
+        )
+        self.assertFalse(
+            self.cd.is_test_included(self.expected_bar_check, ['accred.foo'])
+        )
+        self.assertTrue(
+            self.cd.is_test_included(
+                self.expected_foo_check, ['accred.foo', 'accred.bar']
+            )
+        )
+        self.assertTrue(
+            self.cd.is_test_included(
+                self.expected_bar_check, ['accred.foo', 'accred.bar']
+            )
+        )
+        self.assertFalse(
+            self.cd.is_test_included(self.expected_foo_check, ['accred.baz'])
+        )


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Simplify expected controls.json format.

## Why

The original format isn't intuitive and is overly complex.

## How

- Simplified/flattened the expected content to take a check's class path as a key and a list of accreditations as the value.
- Ensured original format is still valid.
- Added supporting docs.
- Added ControlDescriptor unit tests (squashed two bugs that have been there for 4 years ;) - yeay unit tests!

## Test

- Unit tests succeed as expected
- Code executed in a venv where old format, new format and a combo were used and all scenarios produced the same expected check results.

## Context

- Closes #51 
- In support of #34 
