### PR TITLE
Auto close fetcher session

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+- [FIXED] ComplianceFetcher session object is auto-closed now in tearDownClass.
+
 # 1.2.7
 
 - [CHANGED] Removed PyYAML dependency to resolve downstream dependency issues.

--- a/compliance/fetch.py
+++ b/compliance/fetch.py
@@ -28,7 +28,11 @@ import requests
 class ComplianceFetcher(unittest.TestCase):
     """Compliance fetcher automation TestCase class."""
 
-    _multiprocess_can_split_ = True
+    @classmethod
+    def tearDownClass(cls):
+        """Perform clean up."""
+        if hasattr(cls, '_session'):
+            cls._session.close()
 
     @classmethod
     def session(cls, url=None, creds=None, **headers):


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Ensure that the fetcher session object is closed if it has been opened.

## Why

Best practice...

## How

In the tearDownClass - Check for session, if one exists, close it

## Test

works in a virtualenvironment

## Context

- Fixes #43 
- In support of #34 