### PR TITLE
Add note about sensitive content in notifications

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# UNRELEASED
+
+- [NEW] Added warning for possible sensitive information contained within notifications.
+
 # 1.3.0
 
 - [IMPROVED] Simplified `controls.json` format.  Original format is also supported.

--- a/doc-source/notifiers.rst
+++ b/doc-source/notifiers.rst
@@ -6,12 +6,18 @@ Notifiers
 =========
 
 The last phase in a typical framework check run is the notification
-system.  Multiple notifiers can be targeted as part of this phase  by using
+system.  Multiple notifiers can be targeted as part of this phase by using
 the ``--notify`` option on the ``compliance --check`` command.  Valid
 notifier options are ``stdout``, ``slack``, ``pagerduty``, ``findings``,
 ``gh_issues`` and, ``locker``.  The general idea behind the notification
 system is that each ``test_`` can generate a short notification that has the
 following components:
+
+    **NOTE:** When configuring notifiers, you should be aware of the
+    possibilitythat notifications may contain sensitive information that can be
+    sent to less trusted stores like Slack or public git issue trackers.  So be
+    mindful of check notification content as well as the nature of the forum
+    you intend to send these notifications to.
 
 * title (mandatory): should be a ``property`` of the
   ``ComplianceCheck``:


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add note about sensitive content in notifications

## Why

So that folks are aware of the possibility and to be careful when configuring notifiers.

## How

Add note about sensitive content in notifications notifiers.rst.

## Test

N/A

## Context

Closes #65 
