### PR TITLE
Add better logging and handle git push failures better

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# 1.5.0 (2020-09-14)
+
+- [ADDED] Remote locker push failure notifications were added.
+- [ADDED] Logging for git locker operations was added.
+- [ADDED] Notifier logging was added.
+- [CHANGED] The file descriptor (stdout) notifier always notifies now.
+
 # 1.4.0 (2020-09-03)
 
 - [CHANGED] PagerDuty notifier can send alerts for a subset of the accreditation checks based on the config.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 
-If you want to add to the framework, please familiarise yourself with the code & our [Coding Standards][]. Make a fork of the repository & file a Pull Request from your fork with the changes. You will need to click the checkbox in the template to show you agree to the [Developer Certificate of Origin](../blob/master/DCO1.1.txt).
+If you want to add to the framework, please familiarize yourself with the code & our [Coding Standards][]. Make a fork of the repository & file a Pull Request from your fork with the changes. You will need to click the checkbox in the template to show you agree to the [Developer Certificate of Origin](https://github.com/ComplianceAsCode/auditree-framework/blob/main/DCO1.1.txt).
 
 If you make **regular & substantial contributions** to Auditree, you may want to become a collaborator. This means you can approve pull requests (though not your own) & create releases of the tool. Please [file an issue][new collab] to request collaborator access. A collaborator supports the project, ensuring coding standards are met & best practices are followed in contributed code, cutting & documenting releases, promoting the project etc.
 
 ## Fetchers & checks
 
-If you would like to contribute checks, either add them via PR to[Arboretum][] or push to your own repository & let us know of its existence.
+If you would like to contribute checks, either add them via PR to [Arboretum][] or push to your own repository & let us know of its existence.
 
 There are some guidelines to follow when making a common fetcher or check:
 
@@ -77,9 +77,8 @@ example `[ADDED]`, `[CHANGED]`, etc.
 
 [semver]: https://semver.org/
 [changelog]: https://keepachangelog.com/en/1.0.0/#how
-
 [Arboretum]: https://github.com/ComplianceAsCode/auditree-arboretum
-[Coding Standards]: https://github.com/ComplianceAsCode/auditree-framework/blob/master/doc/coding-standards.rst
+[Coding Standards]: https://complianceascode.github.io/auditree-framework/coding-standards.html
 [flake8]: https://gitlab.com/pycqa/flake8
 [new collab]: https://github.com/ComplianceAsCode/auditree-framework/issues/new?template=new-collaborator.md
 [yapf]: https://github.com/google/yapf

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.4.0'
+__version__ = '1.5.0'

--- a/compliance/scripts/compliance_cli.py
+++ b/compliance/scripts/compliance_cli.py
@@ -88,13 +88,14 @@ class ComplianceCLI(Command):
             metavar='/path/to/creds.ini',
             default='~/.credentials'
         )
+        notify_options = [k for k in get_notifiers().keys() if k != 'stdout']
         self.add_argument(
             '--notify',
             help=(
                 'Specifies a list of notifiers for sending notifications.  '
                 'Valid values (can be a comma separated list - no spaces): '
-                f'{", ".join(get_notifiers().keys())}.  '
-                'Defaults to %(default)s.'
+                f'{", ".join(notify_options)}.  NOTE: In addition to those '
+                'specified, the %(default)s notifier will always execute.'
             ),
             metavar='[slack,gh_issues,...]',
             default='stdout'
@@ -108,6 +109,8 @@ class ComplianceCLI(Command):
         )
 
     def _validate_arguments(self, args):
+        if 'stdout' not in args.notify:
+            args.notify += ',stdout'
         if args.check == '':
             self.parser.error(
                 '--check option requires accreditation grouping(s).'

--- a/compliance/utils/exceptions.py
+++ b/compliance/utils/exceptions.py
@@ -43,3 +43,26 @@ class DependencyFetcherNotFoundError(ValueError):
     """Dependency fetcher not found exception class."""
 
     pass
+
+
+class LockerPushError(Exception):
+    """Locker push exception class."""
+
+    def __init__(self, push_info=None):
+        """
+        Construct the locker push exception.
+
+        :param push_info: a GitPython PushInfo object containing Git remote
+          push information
+        """
+        self.push_info = push_info
+
+    def __str__(self):
+        """Display the error as a string."""
+        msg = 'Push to remote locker failed.\n'
+        if self.push_info:
+            msg += (
+                f'       Summary: {self.push_info.summary}'
+                f'       Error Flags: {self.push_info.flags}'
+            )
+        return msg

--- a/doc-source/coding-standards.rst
+++ b/doc-source/coding-standards.rst
@@ -8,14 +8,14 @@ Coding Standards
 In this project, we use Python as programming language so please
 follow these rules:
 
-* Keep the code tidy using `flake8
+* Keep the code tidy using `yapf
+  <https://pypi.org/project/yapf/>`_ and `flake8
   <http://flake8.pycqa.org/en/latest>`_. Don't introduce new
-  violations and remove them if you spot any. This is enforced now by
-  travis build. To check your code locally, use:
-  
-  ```
-  make lint
-  ```
+  violations and remove them if you spot any. This is enforced by
+  Github Actions builds. To check your code locally, use::
+
+    make code-format
+    make code-lint
 
 * Please provide good unit tests for your code changes. It is
   important to keep a good level of test coverage.
@@ -23,11 +23,9 @@ follow these rules:
 * Document everything you create using docstring within the code. We
   use `sphinx <http://www.sphinx-doc.org>`_ for documentation.
 
-* Test your code locally and make sure it works before creating a PR.
+* Test your code locally and make sure it works before creating a PR::
 
-  ```
-  make unit-tests-with-coverage
-  ```
+    make test
 
 
 Avoid code smells
@@ -65,11 +63,9 @@ Avoid third-party stuff
 Always Test
 ~~~~~~~~~~~
 
-* Always test your code, please dont assume it works. To do this, add
-  unit tests and pay attention to the coverage results that come back.
-  
-  ```
-  make unit-tests-with-coverage
-  ```
+* Always test your code, please don't assume it works. To do this, add
+  unit tests and pay attention to the coverage results that come back::
+
+    make test
 
 * Always make sure that the entire test suite runs cleanly

--- a/test/t_compliance/t_notify/test_base_notify.py
+++ b/test/t_compliance/t_notify/test_base_notify.py
@@ -54,7 +54,7 @@ class BaseNotifierTest(unittest.TestCase):
         }
         controls = create_autospec(ControlDescriptor)
         controls.get_accreditations.return_value = ['infra']
-        notifier = _BaseNotifier(results, controls)
+        notifier = _BaseNotifier(results, controls, push_error=False)
 
         (_, _, _, errored_tests) = notifier._split_by_status(notifier.messages)
 
@@ -84,7 +84,7 @@ class BaseNotifierTest(unittest.TestCase):
         }
         controls = create_autospec(ControlDescriptor)
         controls.get_accreditations.return_value = ['infra']
-        notifier = _BaseNotifier(results, controls)
+        notifier = _BaseNotifier(results, controls, push_error=False)
 
         (_, _, _, errored_tests) = notifier._split_by_status(notifier.messages)
 

--- a/test/t_compliance/t_notify/test_fd_notifier.py
+++ b/test/t_compliance/t_notify/test_fd_notifier.py
@@ -32,20 +32,91 @@ class FDNotifierTest(unittest.TestCase):
         self.fd = StringIO()
 
     def test_notify_with_no_results(self):
-        """Check that FDNotifier does not notify if no results."""
+        """Check that FDNotifier notifies that there are no results."""
         notifier = FDNotifier({}, {}, self.fd)
         notifier.notify()
-        self.assertEqual(self.fd.getvalue(), '')
+        self.assertEqual(
+            self.fd.getvalue(), '\n-- NOTIFICATIONS --\n\nNo results\n'
+        )
 
-    def test_notify_error(self):
+    def test_notify_normal_run(self):
         """Check that FDNotifier notifies a test with Error."""
         results = {
-            'compliance.test.example': {
+            'compliance.test.one': {
                 'status': 'error', 'test': build_test_mock()
+            },
+            'compliance.test.two': {
+                'status': 'warn', 'test': build_test_mock('two', warns=1)
+            },
+            'compliance.test.three': {
+                'status': 'fail', 'test': build_test_mock('three', fails=1)
+            },
+            'compliance.test.four': {
+                'status': 'pass', 'test': build_test_mock('four')
             }
         }
         controls = create_autospec(ControlDescriptor)
         controls.get_accreditations.return_value = ['infra-internal']
         notifier = FDNotifier(results, controls, self.fd)
         notifier.notify()
-        self.assertIn('INFRA-INTERNAL', self.fd.getvalue())
+        self.assertIn(
+            (
+                '\n-- NOTIFICATIONS --\n\n'
+                'Notifications for INFRA-INTERNAL accreditation'
+            ),
+            self.fd.getvalue()
+        )
+        self.assertIn(
+            (
+                'mock check title one - ERROR () Reports: (none) '
+                '| <http://mockedrunbooks/path/to/runbook_one|Run Book>\n'
+                'Check compliance.test.one failed to execute'
+            ),
+            self.fd.getvalue()
+        )
+        self.assertIn(
+            (
+                'mock check title two - WARN (1 warnings) Reports: (none) '
+                '| <http://mockedrunbooks/path/to/runbook_two|Run Book>'
+            ),
+            self.fd.getvalue()
+        )
+        self.assertIn(
+            (
+                'mock check title three - FAIL (1 failures) Reports: (none) '
+                '| <http://mockedrunbooks/path/to/runbook_three|Run Book>'
+            ),
+            self.fd.getvalue()
+        )
+        self.assertIn(
+            'PASSED checks: mock check title four', self.fd.getvalue()
+        )
+
+    def test_notify_push_error(self):
+        """Check that FDNotifier notifies a test with Error."""
+        results = {
+            'compliance.test.one': {
+                'status': 'error', 'test': build_test_mock()
+            },
+            'compliance.test.two': {
+                'status': 'warn', 'test': build_test_mock('two', warns=1)
+            },
+            'compliance.test.three': {
+                'status': 'fail', 'test': build_test_mock('three', fails=1)
+            },
+            'compliance.test.four': {
+                'status': 'pass', 'test': build_test_mock('four')
+            }
+        }
+        controls = create_autospec(ControlDescriptor)
+        controls.get_accreditations.return_value = ['infra-internal']
+        notifier = FDNotifier(results, controls, self.fd, push_error=True)
+        notifier.notify()
+        self.assertEqual(
+            (
+                '\n-- NOTIFICATIONS --\n\n'
+                'All accreditation checks:  '
+                'Evidence/Results failed to push to remote locker.\n'
+            ),
+            self.fd.getvalue()
+        )

--- a/test/t_compliance/t_notify/test_md_notify.py
+++ b/test/t_compliance/t_notify/test_md_notify.py
@@ -46,7 +46,7 @@ class BaseNotifierTest(unittest.TestCase):
 
         controls = create_autospec(ControlDescriptor)
         controls.get_accreditations.return_value = ['infra']
-        notifier = _BaseMDNotifier(results, controls)
+        notifier = _BaseMDNotifier(results, controls, push_error=False)
 
         split_tests = notifier._split_by_status(notifier.messages)
 

--- a/test/t_compliance/t_notify/test_slack_notifier.py
+++ b/test/t_compliance/t_notify/test_slack_notifier.py
@@ -53,7 +53,7 @@ class SlackNotifierTest(unittest.TestCase):
         args, kwargs = post_mock.call_args
         self.assertTrue(args[0].startswith('https://hooks.slack.com'))
         msg = json.loads(kwargs['data'])
-        self.assertIn('failed to run', msg['attachments'][0]['text'])
+        self.assertIn('failed to execute', msg['attachments'][0]['text'])
 
     @patch('requests.post')
     @patch('compliance.notify.get_config')
@@ -81,9 +81,9 @@ class SlackNotifierTest(unittest.TestCase):
         self.assertTrue(args[0].startswith('https://hooks.slack.com'))
         msg = json.loads(kwargs['data'])
         self.assertEqual(len(msg['attachments']), 3)
-        self.assertEqual('PASSED tests', msg['attachments'][2]['title'])
+        self.assertEqual('PASSED checks', msg['attachments'][2]['title'])
         for att in msg['attachments'][:-1]:
-            self.assertIn('failed to run', att['text'])
+            self.assertIn('failed to execute', att['text'])
 
     @patch('requests.post')
     @patch('compliance.notify.get_config')
@@ -127,7 +127,7 @@ class SlackNotifierTest(unittest.TestCase):
         self.assertTrue(args[0].startswith('https://hooks.slack.com'))
         msg = json.loads(kwargs['data'])
         self.assertEqual(len(msg['attachments']), 3)
-        self.assertEqual('PASSED tests', msg['attachments'][2]['title'])
+        self.assertEqual('PASSED checks', msg['attachments'][2]['title'])
         for att in msg['attachments'][:-1]:
             testname = att['title'].rsplit(' ', 1)[1]
             url = f'http://mockedrunbooks/path/to/runbook_{testname}'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Locker git operation logging was added as was logging for all of the notifiers.  Additionally, notifier behavior was modified to handle when a git remote locker push fails more gracefully.

## Why

Logging the process is always helpful for triaging execution issues as is better notifier behavior around remote locker push failures.

## How

- Add locker git ops logging
- Add notifier logging
- Ensure STDOUT notifier always runs
- Add remote locker push failure notification behavior
- Fix links in CONTRIBUTING.md
- Fix formatting and content in coding standards rst
- Update notifier unit tests

## Test

- Original execution/notification behavior is not compromised
- When a git remote locker push fails, the FD (STDOUT) notifier, Slack notifier, and GH Issues (summary by accred version) all notify by accreditation that all check results and evidence failed to be pushed to the locker.  Whereas for GH Issues (per check), PagerDuty, and Findings notifiers all do not trigger in the event of a push failure.  Logging is provided saying so.
- A push failure ERROR is logged to the execution log wit details from git.

## Context

- Closes #49 
- Closes #53 
