### PR TITLE
Add evidence locker TOC

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,69 +1,74 @@
-# 1.5.0 (2020-09-14)
+# [1.6.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.0)
+
+- [ADDED] Check reports table of contents now appended to an evidence locker's README.
+- [ADDED] `ComplianceCheck.get_historical_evidence` supports historical evidence retrieval.
+
+# [1.5.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.5.0)
 
 - [ADDED] Remote locker push failure notifications were added.
 - [ADDED] Logging for git locker operations was added.
 - [ADDED] Notifier logging was added.
 - [CHANGED] The file descriptor (stdout) notifier always notifies now.
 
-# 1.4.0 (2020-09-03)
+# [1.4.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.4.0)
 
 - [CHANGED] PagerDuty notifier can send alerts for a subset of the accreditation checks based on the config.
 - [ADDED] A warning for possible sensitive information contained within notifications was added.
 
-# 1.3.0 (2020-09-01)
+# [1.3.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.3.0)
 
 - [CHANGED] Simplified `controls.json` format.  Original format is also supported.
 - [ADDED] Documentation for `controls.json` and check execution was added.
 - [ADDED] ControlDescriptor unit tests were added.
 - [FIXED] ComplianceFetcher session object is auto-closed now in tearDownClass.
 
-# 1.2.7 (2020-08-28)
+# [1.2.7](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.7)
 
 - [CHANGED] Removed PyYAML dependency to resolve downstream dependency issues.
 - [CHANGED] Removed Github.get_issue_template helper method.
 
-# 1.2.6 (2020-08-28)
+# [1.2.6](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.6)
 
 - [FIXED] ComplianceFetcher.session can now be reset.
 
-# 1.2.5 (2020-08-26)
+# [1.2.5](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.5)
 
 - [FIXED] Credentials section bug affecting the Slack notifier is squashed.
 
-# 1.2.4 (2020-08-24)
+# [1.2.4](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.4)
 
 - [CHANGED] Fetchers and checks that failed to load appear as errors in STDERR now.
 
-# 1.2.3 (2020-08-18)
+# [1.2.3](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.3)
 
 - [CHANGED] Github service `get_commit_details` now take `path` as an optional argument.
 
-# 1.2.2 (2020-08-14)
+# [1.2.2](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.2)
 
 - [FIXED] Github service branch protection method now returns "required_signatures" content.
 
-# 1.2.1 (2020-08-12)
+# [1.2.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.1)
 
 - [FIXED] Notifier `msg_` methods are now accurately found based on check `test_` method names.
 
-# 1.2.0 (2020-08-11)
+# [1.2.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.2.0)
 
 - [ADDED] Branch option to retrieving commit details from the Github service was added.
 
-# 1.1.0 (2020-08-11)
+# [1.1.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.1.0)
 
 - [ADDED] Repository details retrieval was added to Github service class.
 - [ADDED] Recent commit details retrieval was added to Github service class.
 - [ADDED] Repository branch protection details retrieval was added to Github service class.
 
-# 1.0.2 (2020-07-28)
+# [1.0.2](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.0.2)
 
 - [FIXED] Added PyYAML library as a dependency to resolve Github service issue.
 
-# 1.0.1 (2020-07-27)
+# [1.0.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.0.1)
 
 - [FIXED] Added external evidence as a valid evidence type to evidence map.
 
-# 1.0.0 (2020-07-21)
+# [1.0.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.0.0)
 
 - [ADDED] Made the Auditree Framework public.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft templates

--- a/README.md
+++ b/README.md
@@ -95,32 +95,7 @@ This will update the files in `doc` with the latest documentation. These files s
 
 ## Try it
 
-First, create an empty [credentials file][]:
-
-```shell
-touch ~/.credentials
-```
-
-Go to the demo checks and install required dependencies:
-
-```shell
-cd doc/demo-checks
-pip install -r requirements.txt
-```
-
-Run the fetchers:
-
-```shell
-compliance --fetch -v --evidence=local -C setup.json
-```
-
-And then run the checks of the demo accreditations:
-
-```shell
-compliance --check demo.accreditation1,demo.accreditation2 --evidence=local -v -C setup.json
-```
-
-See a more detailed [quick start guide][].
+Coming soon...
 
 ## Contribute
 

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.5.0'
+__version__ = '1.6.0'

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -286,6 +286,17 @@ class ComplianceCheck(unittest.TestCase):
         else:
             self.add_failures(msg, sorted(diff))
 
+    def get_historical_evidence(self, evidence_path, evidence_dt):
+        """
+        Retrieve historical evidence from the locker and track as metadata.
+
+        :param evidence_path: the evidence path.
+        :param evidence_dt: the evidence date.
+        """
+        evidence = self.locker.get_evidence(evidence_path, True, evidence_dt)
+        self.add_evidence_metadata(evidence_path, evidence_dt)
+        return evidence
+
     def add_evidence_metadata(self, evidence_path, evidence_dt=None):
         """
         Add evidence metadata to the evidences property of each check.

--- a/compliance/locker.py
+++ b/compliance/locker.py
@@ -41,7 +41,8 @@ import git
 INDEX_FILE = 'index.json'
 DAY = 60 * 60 * 24
 AE_DEFAULT = 30 * DAY
-AE_EXEMPT = [INDEX_FILE, 'README.md', 'readme.md', 'Readme.md']
+READMES = ['README.md', 'readme.md', 'Readme.md']
+AE_EXEMPT = [INDEX_FILE] + READMES
 
 
 class Locker(object):

--- a/compliance/notify.py
+++ b/compliance/notify.py
@@ -158,9 +158,7 @@ class _BaseNotifier(object):
 
         return [
             link_format.format(
-                url=test_obj.locker.get_remote_location(
-                    report.path, include_commit=True
-                ),
+                url=test_obj.locker.get_remote_location(report.path),
                 name=report.name
             ) for report in test_obj.reports
         ]

--- a/compliance/report.py
+++ b/compliance/report.py
@@ -16,13 +16,13 @@
 
 import copy
 import datetime
-import json
 import logging
 import os
 import traceback
 
 from compliance.config import get_config
 from compliance.evidence import get_evidence_by_path
+from compliance.utils.data_parse import format_json
 
 import jinja2
 
@@ -49,7 +49,9 @@ class ReportBuilder(object):
         test_by_class = self._get_test_by_class()
         with self.locker:
             self._generate_reports(test_by_class)
-            self._generate_raw_results()
+            rpt_metadata = self.locker.get_reports_metadata()
+            self.generate_toc(rpt_metadata)
+            self.generate_check_results(rpt_metadata)
 
     def render_evidence_with_template(self, evidence, test_obj):
         """
@@ -76,11 +78,9 @@ class ReportBuilder(object):
             'builder': self,
             'now': now
         }
-        content = jinja2.Environment(
-            loader=jinja2.FileSystemLoader(path),
-            autoescape=True,
-        ).get_template(filename).render(context)
-        evidence.set_content(content)
+        loader = jinja2.FileSystemLoader(path)
+        env = jinja2.Environment(loader=loader, autoescape=True)
+        evidence.set_content(env.get_template(filename).render(context))
 
     def get_template_for(self, test_obj, evidence):
         """
@@ -99,27 +99,86 @@ class ReportBuilder(object):
             return os.path.join(tmpl_dir, 'default.md.tmpl')
         return tmpl_path
 
-    def _generate_raw_results(self):
-        """Create a check results JSON file stored in the evidence locker."""
-        self.locker.add_content_to_locker(
-            json.dumps(
-                self._munge_chk_results(self.locker.get_reports_metadata()),
-                indent=2,
-                sort_keys=True,
-                separators=(',', ': '),
-                skipkeys=True,
-                default=str
-            ),
-            filename='check_results.json'
-        )
+    def generate_toc(self, rpt_metadata):
+        """
+        Generate a check reports table of contents.
 
-    def _munge_chk_results(self, rpt_metadata):
+        This method generates a TOC based on all report evidence metadata and
+        appends that TOC to the bottom of an evidence locker's README.md file.
+
+        :param rpt_metadata: Metadata from all report evidence index.json files
+        """
+        readme = 'README.md'
+        if 'readme.md' in os.listdir(self.locker.local_path):
+            readme = 'readme.md'
+        elif 'Readme.md' in os.listdir(self.locker.local_path):
+            readme = 'Readme.md'
+        content_as_str = self.locker.get_content_from_locker(filename=readme)
+        rpts = []
+        for rpt, meta in rpt_metadata.items():
+            if meta.get('pruned_by'):
+                continue
+            rpt_descr = meta['description'] or rpt.rsplit('/', 1).pop()
+            rpt_url = self.locker.get_remote_location(rpt, False)
+            check = meta['checks'][0].rsplit('.', 1).pop(0)
+            evidences = []
+            for ev in meta['evidence']:
+                ev_descr = ev['description'] or ev['path'].rsplit('/', 1).pop()
+                if not ev.get('partitions'):
+                    ev_url = self.locker.get_remote_location(
+                        ev['path'], False, ev['commit_sha']
+                    )
+                    evidences.append(
+                        {
+                            'descr': ev_descr,
+                            'url': ev_url,
+                            'from': ev['last_update']
+                        }
+                    )
+                else:
+                    for hash_key, part in ev['partitions'].items():
+                        ev_part_descr = f'{ev_descr} - {hash_key} partition'
+                        head, tail = os.path.split(ev['path'])
+                        part_path = os.path.join(head, f'{hash_key}_{tail}')
+                        ev_url = self.locker.get_remote_location(
+                            part_path, False, part['commit_sha']
+                        )
+                        evidences.append(
+                            {
+                                'descr': ev_part_descr,
+                                'url': ev_url,
+                                'from': ev['last_update']
+                            }
+                        )
+            accreditations = self.controls.get_accreditations(check)
+            rpts.append(
+                {
+                    'descr': rpt_descr,
+                    'url': rpt_url,
+                    'check': check,
+                    'accreditations': ', '.join(sorted(accreditations)),
+                    'from': meta['last_update'],
+                    'evidences': sorted(evidences, key=lambda ev: ev['descr'])
+                }
+            )
+        context = {
+            'original': content_as_str.split('\n') if content_as_str else [],
+            'reports': sorted(rpts, key=lambda r: r['descr'])
+        }
+        loader = jinja2.FileSystemLoader(get_config().get_template_dir(self))
+        env = jinja2.Environment(loader=loader, autoescape=True)
+        content = env.get_template('readme_toc.md.tmpl').render(context)
+        self.locker.add_content_to_locker(content, filename=readme)
+
+    def generate_check_results(self, rpt_metadata):
         """
         Combine the check execution results with associated reports metadata.
 
         This method combines check results with details about associated
         reports and evidences used, found in the report metadata.  It
         returns a dictionary keyed by check class dot path.
+
+        :param rpt_metadata: Metadata from all report evidence index.json files
         """
         chk_results = {}
         for rpt, meta in rpt_metadata.items():
@@ -154,7 +213,10 @@ class ReportBuilder(object):
                 }
             else:
                 chk_results[check_class]['reports'][rpt] = meta['description']
-        return chk_results
+        self.locker.add_content_to_locker(
+            format_json(chk_results, skipkeys=True, default=str),
+            filename='check_results.json'
+        )
 
     def _get_test_by_class(self):
         """
@@ -171,7 +233,6 @@ class ReportBuilder(object):
             test_obj = info['test'].test
             if not hasattr(test_obj, 'get_reports'):
                 continue
-
             test_class = test_obj.__class__
             if test_class in retval:
                 retval[test_class].__dict__.update(test_obj.__dict__)
@@ -195,7 +256,6 @@ class ReportBuilder(object):
                 info for info in self.results.values()
                 if info['test'].test.__class__ == test_class
             ]
-
             try:
                 reports = test_obj.get_reports()
             except (AttributeError, ValueError) as e:
@@ -206,7 +266,6 @@ class ReportBuilder(object):
                 for info in test_infos:
                     info['status'] = 'error'
                 continue
-
             for r in reports:
                 try:
                     self.__render_report(r, test_obj, test_infos)
@@ -242,9 +301,7 @@ class ReportBuilder(object):
             if not report.startswith('reports/'):
                 path = 'reports/' + report
             evidence = get_evidence_by_path(path)
-
         self.render_evidence_with_template(evidence, test_obj)
-
         self.locker.add_evidence(
             evidence,
             self._get_checks(test_obj),

--- a/compliance/templates/readme_toc.md.tmpl
+++ b/compliance/templates/readme_toc.md.tmpl
@@ -1,0 +1,48 @@
+{#- -*- mode:jinja2; coding: utf-8 -*- -#}
+{#
+Copyright (c) 2020 IBM Corp. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+{%- if original|length == 0 -%}
+# Evidence Locker
+{%- else -%}
+{%- set ns = namespace(found=false) -%}
+{%- for line in original if ns.found == false -%}
+{%- if line == '## Table of Contents - Check Reports' -%}
+{%- set ns.found = true -%}
+{%- else -%}
+{{ line }}
+{% endif %}
+{%- endfor -%}
+{%- endif -%}
+## Table of Contents - Check Reports
+
+{% for rpt in reports -%}
+<details>
+<summary><a href="{{ rpt['url'] }}">{{ rpt['descr'] }}</a></summary>
+
+- Accreditations: **{{ rpt['accreditations']|upper }}**
+- Check:`{{ rpt['check'] }}`
+- From: {{ rpt['from'] }}
+{%- if rpt['evidences']|length == 0 %}
+- Evidences used: N/A
+{% else %}
+- Evidences used:
+{%- for ev in rpt['evidences'] %}
+   - <a href="{{ ev['url'] }}">{{ ev['descr'] }}</a> from {{ ev['from'] }}
+{%- endfor -%}
+{%- endif %}
+</details>
+
+{% endfor -%}

--- a/compliance/utils/data_parse.py
+++ b/compliance/utils/data_parse.py
@@ -56,7 +56,7 @@ def get_sha256_hash(key, size=None):
     return sha256_hash[:size]
 
 
-def format_json(data):
+def format_json(data, **addl_kwargs):
     """
     Provide a JSON string formatted to the standards of the library.
 
@@ -65,10 +65,13 @@ def format_json(data):
     by this library.
 
     :param data: The data structure to be formatted.
+    :param add_kwargs: Additional json.dumps options
 
     :returns: A formatted JSON string.
     """
-    return json.dumps(data, indent=2, sort_keys=True, separators=(',', ': '))
+    return json.dumps(
+        data, indent=2, sort_keys=True, separators=(',', ': '), **addl_kwargs
+    )
 
 
 def deep_merge(a, b, path=None, append=False):

--- a/doc-source/quick-start.rst
+++ b/doc-source/quick-start.rst
@@ -10,32 +10,27 @@ understand, so you may want to have a look into
 :ref:`design-principles` section.
 
 The Auditree framework requires, at least, one directory with the
-fetchers and checks. In order to learn how to use it, let's use a
-demo folder with a simple set of fetchers and checks. You can find it
-at `doc/demo-checks`::
-
-  $ cd doc/demo-checks
-  $ mkvirtual env ** #TODO CHECK mkvirtual **
-  $ . ./env/bin/activate
-  $ pip install -r requirements.txt
+fetchers and checks.
 
 A normal execution is broken down in 2 steps:
 
 * Run the fetchers::
 
-    $ compliance --fetch .
+    $ compliance --fetch evidence local
 
-  This executes all the fetchers located at ``demo/fetchers``
+  This executes all the fetchers that the framework can find
   and generates a git repository locally at ``/$TMPDIR/compliance``.
 
 * Run the checks::
 
-    $ compliance --check 'demo.accreditation1,demo.accreditation2' .
+    $ compliance --check 'accred1,accred2' .
 
-  This executes the checks located at ``demo/checks``, creates the reports,
-  executes notifiers (you can see the messages in the output), and generates a
-  file called ``check_results.json`` with detailed information about the
-  execution.  The file is put into the evidence locker by default.
+  This executes the checks that are associated with the specified accreditations,
+  creates the reports, executes notifiers (you can see the messages in the output),
+  and generates a file called ``check_results.json`` with detailed information about
+  the execution.  The file is put into the evidence locker by default.
+  Accreditation to check mapping is handled in the ``controls.json`` file.  More
+  on that below.
 
 Advanced Topics
 ---------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ long_description_content_type = text/markdown
 long_description = file: README.md
 
 [options]
+include_package_data = True
 packages = find:
 install_requires =
     inflection>=0.3.1


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Add evidence locker TOC
- Add helper method to ComplianceCheck for retrieving historical evidence

## Why

- TOC provides a nicely formatted table of contents for reports with links to reports, evidence used, and other details

## How

- Update ReportBuilder logic to include appending a TOC to the end of an evidence locker's README

## Test

- All fetchers and checks and reports all function as before
- TOC is rendered on a locker's README as expected

## Context

Closes #38 
Also ref: #70 
