### PR TITLE
Fix TOC to handle old/abandoned rpt evidence gracefully

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.6.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.1)
+
+- [FIXED] Table of contents now handles old/abandoned report evidence metadata appropriately.
+
 # [1.6.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.0)
 
 - [ADDED] Check reports table of contents now appended to an evidence locker's README.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.6.0'
+__version__ = '1.6.1'

--- a/compliance/report.py
+++ b/compliance/report.py
@@ -120,9 +120,9 @@ class ReportBuilder(object):
                 continue
             rpt_descr = meta['description'] or pathlib.Path(rpt).name
             rpt_url = self.locker.get_remote_location(rpt, False)
-            check = meta['checks'][0].rsplit('.', 1).pop(0)
+            check = meta.get('checks', ['N/A'])[0].rsplit('.', 1).pop(0)
             evidences = []
-            for ev in meta['evidence']:
+            for ev in meta.get('evidence', []):
                 ev_path = pathlib.Path(ev['path'])
                 ev_descr = ev['description'] or ev_path.name
                 if not ev.get('partitions'):
@@ -151,13 +151,13 @@ class ReportBuilder(object):
                                 'from': ev['last_update']
                             }
                         )
-            accreditations = self.controls.get_accreditations(check)
+            accreditations = sorted(self.controls.get_accreditations(check))
             rpts.append(
                 {
                     'descr': rpt_descr,
                     'url': rpt_url,
                     'check': check,
-                    'accreditations': ', '.join(sorted(accreditations)),
+                    'accreditations': ', '.join(accreditations) or 'N/A',
                     'from': meta['last_update'],
                     'evidences': sorted(evidences, key=lambda ev: ev['descr'])
                 }


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix TOC to handle old/abandoned rpt evidence gracefully

## Why

So the report and notification process and complete successfully

## How

Handle no checks and evidence elements in the report metadata better

## Test

All checks run, TOC is generated

## Context

#38 
