### PR TITLE
Fix TOC output in README for lockers without a README initially

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.6.2](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.2)
+
+- [FIXED] Table of contents now handled appropriately for locker without a README.
+
 # [1.6.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.1)
 
 - [FIXED] Table of contents now handles old/abandoned report evidence metadata appropriately.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.6.1'
+__version__ = '1.6.2'

--- a/compliance/templates/readme_toc.md.tmpl
+++ b/compliance/templates/readme_toc.md.tmpl
@@ -25,7 +25,8 @@ limitations under the License.
 {{ line }}
 {% endif %}
 {%- endfor -%}
-{%- endif -%}
+{%- endif %}
+
 ## Table of Contents - Check Reports
 
 {% for rpt in reports -%}


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix TOC output in README for lockers without a README initially.

## Why

Originally new README content wasn't rendering correctly because an empty line was needed between the new README heading `# Evidence Locker` and the start of the TOC.

## How

Added an empty line in the template.

## Test

- New README generated renders cleanly
- Existing README with TOC retains correct functionality

## Context

#38 
