### PR TITLE
Add execution times to fetcher and check logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.6.3](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.3)
+
+- [ADDED] Fetcher and check execution times are now included in execution logging.
+
 # [1.6.2](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.2)
 
 - [FIXED] Table of contents now handled appropriately for locker without a README.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.6.2'
+__version__ = '1.6.3'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add execution times to fetcher and check logging

## Why

This will help users identify long running fetchers and checks

## How

Update Result class used by fetcher and check runners.

## Test

- Display execution times in seconds rounded to 2 decimals for fetchers and checks
- Fetchers and checks both execute as expected
- option only runs if `-v` verbose mode is requested
- Sample output:

```
test_abandoned_evidence (arboretum.auditree.checks.test_abandoned_evidence.AbandonedEvidenceCheck)
Check for evidence that may have been abandoned. ... ok
test_abandoned_evidence (arboretum.auditree.checks.test_abandoned_evidence.AbandonedEvidenceCheck)
Check for evidence that may have been abandoned. - ran in: 0.270s
test_auditree_arboretum_version (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check auditree-arboretum version matches latest release. ... ok
test_auditree_arboretum_version (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check auditree-arboretum version matches latest release. - ran in: 0.031s
test_auditree_framework_version (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check auditree-framework version matches latest release. ... ok
test_auditree_framework_version (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check auditree-framework version matches latest release. - ran in: 0.032s
test_auditree_harvest_version (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check auditree-harvest version matches latest release. ... ok
test_auditree_harvest_version (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check auditree-harvest version matches latest release. - ran in: 0.032s
test_python_package_deltas (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check the last two Python environments against each other. ... ok
test_python_package_deltas (arboretum.auditree.checks.test_python_packages.PythonPackageCheck)
Check the last two Python environments against each other. - ran in: 0.032s

----------------------------------------------------------------------
Ran 5 tests in 0.397s


```

## Context

Closes #75 
