### PR TITLE
Expose direct REST calls in Github service

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.6.5](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.5)
+
+- [ADDED] Direct calls to the GH API can be made using the Github service now.
+
 # [1.6.4](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.4)
 
 - [ADDED] Demo set of fetchers and checks added.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.6.4'
+__version__ = '1.6.5'

--- a/compliance/utils/services/github.py
+++ b/compliance/utils/services/github.py
@@ -430,6 +430,31 @@ class Github(object):
             'get', f'repos/{repo}/branches/{branch}/protection'
         )
 
+    def make_request(self, method, url, parse=True, **kwargs):
+        """
+        Perform a REST call to the Github API.
+
+        :param method: HTTP request method
+        :param url: The URL to make the request to
+        :param parse: Return the JSON response content, defaults to True.  If
+          False then the entire response is returned
+        :param kwargs: Additional arguments added directly to the request call
+
+        :returns: response content from the request made
+        """
+        return self._make_request(method, url, parse, **kwargs)
+
+    def paginate_api(self, api_url, **kwargs):
+        """
+        Perform GET calls handling pagination.
+
+        :param api_url: The URL to make the GET request to
+        :param kwargs: Additional arguments added directly to the request call
+
+        :returns: Combined paginated JSON content
+        """
+        return self._paginate_api(api_url, **kwargs)
+
     def _make_request(self, method, url, parse=True, **kwargs):
         r = self.session.request(method, url, **kwargs)
         r.raise_for_status()


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Expose direct REST calls in Github service

## Why

For any functionality not provided by service, a user can make the required calls directly

## How

Provide `make_request` and `paginate_api` method calls

## Test

N/A

## Context

https://github.com/ComplianceAsCode/auditree-arboretum/pull/38
