### PR TITLE
Add handling subclassed evidence support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# [1.7.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.7.0)
+
+- [ADDED] Check evidence decorators and context manager now support subclassed evidence.
+- [ADDED] Evidence objects now have a content_as_json property.
+
 # [1.6.5](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.6.5)
 
 - [ADDED] Direct calls to the GH API can be made using the Github service now.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.6.5'
+__version__ = '1.7.0'

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -835,19 +835,19 @@ def _store_wrapper(self, evidence_path, func, type_name):
 
 
 def _with_evidence_decorator(from_evidences, f, type_str):
-    prefix = f'{type_str}/'
     from_evs = []
     for from_ev in from_evidences:
         path = from_ev
-        ev_class = None
+        # Default the evidence class to evidence of type type_str.
+        # If from_ev is a LazyLoader and its evidence class is of the type
+        # type_str then set the evidence class to the from_ev evidence class.
+        ev_class = get_evidence_class(type_str)
         if isinstance(from_ev, LazyLoader):
             path = from_ev.path
-            if issubclass(from_ev.ev_class, get_evidence_class(type_str)):
+            if issubclass(from_ev.ev_class, ev_class):
                 ev_class = from_ev.ev_class
-        if not path.startswith(prefix):
-            path = f'{prefix}{path}'
-        if not ev_class:
-            ev_class = get_evidence_class(type_str)
+        # Ensure path is the full relative path including the type root.
+        path = str(PurePath(type_str).joinpath(*PurePath(path).parts[-2:]))
         from_evs.append(LazyLoader(path, ev_class))
 
     if hasattr(f, 'args'):

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -517,11 +517,11 @@ class evidences(object):  # noqa: N801
             path = from_evidence.path
             ev_class = from_evidence.ev_class
             ev_types = get_evidence_types()
-            if not any(path.startswith(f'{et}/') for et in ev_types):
+            if not any(PurePath(path).parts[0] == et for et in ev_types):
                 for ev_type in ev_types:
                     base_evidence_class = get_evidence_class(ev_type)
                     if ev_class and issubclass(ev_class, base_evidence_class):
-                        path = f'{ev_type}/{path}'
+                        path = str(PurePath(ev_type).joinpath(path))
                         break
         evidence = get_evidence_by_path(path, self.locker)
         base_evidence_class = get_evidence_class(evidence.rootdir)

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -521,7 +521,7 @@ class evidences(object):  # noqa: N801
                 for ev_type in ev_types:
                     base_evidence_class = get_evidence_class(ev_type)
                     if ev_class and issubclass(ev_class, base_evidence_class):
-                        path = str(PurePath(ev_type).joinpath(path))
+                        path = str(PurePath(ev_type, path))
                         break
         evidence = get_evidence_by_path(path, self.locker)
         base_evidence_class = get_evidence_class(evidence.rootdir)
@@ -847,7 +847,8 @@ def _with_evidence_decorator(from_evidences, f, type_str):
             if issubclass(from_ev.ev_class, ev_class):
                 ev_class = from_ev.ev_class
         # Ensure path is the full relative path including the type root.
-        path = str(PurePath(type_str).joinpath(*PurePath(path).parts[-2:]))
+        if PurePath(path).parts[0] != type_str:
+            path = str(PurePath(type_str, path))
         from_evs.append(LazyLoader(path, ev_class))
 
     if hasattr(f, 'args'):

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -16,8 +16,9 @@
 
 import inspect
 import json
-import os
+from collections import namedtuple
 from functools import wraps
+from pathlib import PurePath
 
 from compliance.check import ComplianceCheck
 from compliance.config import get_config
@@ -55,14 +56,11 @@ class _BaseEvidence(object):
     """
 
     def __init__(self, name, category, ttl=DAY, description='', **kwargs):
-        self.ttl = ttl
+        self._name = name
         self.category = category
-
-        self._name, self.extension = os.path.splitext(name)
-        self._name = substitute_config(self._name)
-        self.extension = self.extension.replace('.', '')
-        self._content = None
+        self.ttl = ttl
         self.description = description
+        self._content = None
 
     @classmethod
     def from_evidence(cls, evidence):
@@ -82,20 +80,36 @@ class _BaseEvidence(object):
         return cls(locker.get_evidence(path))
 
     @property
-    def name(self):
-        return self._name + '.' + self.extension
-
-    @property
-    def path(self):
-        return os.path.join(self.dir_path, self.name)
+    def rootdir(self):
+        raise NotImplementedError('The root directory is not set.')
 
     @property
     def dir_path(self):
-        return os.path.join(self.rootdir, self.category)
+        return str(PurePath(self.rootdir).joinpath(self.category))
+
+    @property
+    def name(self):
+        return substitute_config(self._name)
+
+    @property
+    def path(self):
+        return str(PurePath(self.dir_path).joinpath(self.name))
+
+    @property
+    def extension(self):
+        return PurePath(self.name).suffix.lstrip('.')
 
     @property
     def content(self):
         return self._content
+
+    @property
+    def content_as_json(self):
+        if self.extension != 'json':
+            return
+        if not hasattr(self, '_content_as_json'):
+            self._content_as_json = json.loads(self.content)
+        return self._content_as_json
 
     def set_content(self, str_content):
         self._content = str_content
@@ -405,6 +419,9 @@ class derived_evidence(object):  # noqa: N801
             self.locker.add_evidence(self.evidences['derived'])
 
 
+FromEvidence = namedtuple('FromEvidence', 'path ev_class', defaults=[None])
+
+
 class evidences(object):  # noqa: N801
     """
     Helper context manager for a typical ``test_`` method implementation.
@@ -428,41 +445,51 @@ class evidences(object):  # noqa: N801
     is yielded by this context manager.
     """
 
-    def __init__(self, obj, evidence_paths):
+    def __init__(self, obj, from_evidences):
         """
         Construct and initialize the evidences context manager.
 
         :param obj: Either a check or locker object.  Needed for backward
           compatibility of evidences context manager.
-        :param sources: The paths to the evidences within the evidence
-          locker.  This can be a list, a dict or a string.
-          For (list) example, ``['src/evidence.json', ...]``.
-          For (dict) example, ``{'evidence1': 'src/evidence.json', ...}.
-          For (str) example, ``'src/evidence.json'``.
+        :param from_evidences: The paths to evidences within the evidence
+          locker.  It can be any of the following:
+          - A string path
+          - A FromEvidence namedtuple
+          - A list of string paths or FromEvidence namedtuples or a
+          combination of string paths and FromEvidence namedtuples
+          - A dictionary where a key is an evidence short name and a value
+          is either string path or a FromEvidence namedtuple
+
+          Using the FromEvidence namedtuple tells this context manager to cast
+          your evidence as a subclass of one of the framework's base evidence
+          classes.
         """
         if isinstance(obj, ComplianceCheck):
             self.check = obj
             self.locker = self.check.locker
         else:
             self.locker = obj
-        self.evidence_paths = evidence_paths
+        self.from_evidences = from_evidences
 
     def __enter__(self):
         """Perform check evidences pre-processing."""
         evidence = {}
         evidence_list = []
-        if isinstance(self.evidence_paths, list):
-            for path in self.evidence_paths:
-                evidence[path] = get_evidence_by_path(path, self.locker)
-                evidence_list.append(evidence[path].path)
-        elif isinstance(self.evidence_paths, dict):
-            for evidence_name, path in self.evidence_paths.items():
-                evidence[evidence_name] = get_evidence_by_path(
-                    path, self.locker
-                )
+        if isinstance(self.from_evidences, list):
+            for from_evidence in self.from_evidences:
+                path = from_evidence
+                if isinstance(from_evidence, FromEvidence):
+                    # preserve original path to be used as key of evidence dict
+                    path = from_evidence.path
+                ev = self._get_evidence(from_evidence)
+                evidence[path] = ev
+                evidence_list.append(ev.path)
+        elif isinstance(self.from_evidences, dict):
+            for evidence_name, from_evidence in self.from_evidences.items():
+                evidence[evidence_name] = self._get_evidence(from_evidence)
                 evidence_list.append(evidence[evidence_name].path)
-        elif isinstance(self.evidence_paths, str):
-            evidence = get_evidence_by_path(self.evidence_paths, self.locker)
+        else:
+            evidence = self._get_evidence(self.from_evidences)
             evidence_list.append(evidence.path)
         if hasattr(self, 'check'):
             for ev_path in evidence_list:
@@ -472,6 +499,32 @@ class evidences(object):  # noqa: N801
     def __exit__(self, typ, val, traceback):
         """Perform check evidences post-processing."""
         pass
+
+    def _get_evidence(self, from_evidence):
+        """
+        Retrieve an evidence instance based on the from_evidence provided.
+
+        from_evidence can be either a path to the evidence in the locker as a
+        string or a FromEvidence namedtuple object that contains the path as a
+        string and an evidence class to cast the evidence as.
+        """
+        path = from_evidence
+        ev_class = None
+        if isinstance(from_evidence, FromEvidence):
+            path = from_evidence.path
+            ev_class = from_evidence.ev_class
+            ev_types = get_evidence_types()
+            if not any(path.startswith(f'{et}/') for et in ev_types):
+                for ev_type in ev_types:
+                    base_evidence_class = get_evidence_class(ev_type)
+                    if ev_class and issubclass(ev_class, base_evidence_class):
+                        path = f'{ev_type}/{path}'
+                        break
+        evidence = get_evidence_by_path(path, self.locker)
+        base_evidence_class = get_evidence_class(evidence.rootdir)
+        if not ev_class or not issubclass(ev_class, base_evidence_class):
+            ev_class = base_evidence_class
+        return ev_class.from_evidence(evidence)
 
 
 __init_map = {
@@ -496,6 +549,11 @@ def get_evidence_class(evidence_type):
     :returns: the appropriate evidence class.
     """
     return __init_map.get(evidence_type)
+
+
+def get_evidence_types():
+    """Provide a list of all valid evidence types."""
+    return list(__init_map.keys())
 
 
 def get_evidence_by_path(path, locker=None):
@@ -683,26 +741,26 @@ def store_derived_evidence(evidences, target):
     return decorator
 
 
-def with_raw_evidences(*evidence_paths):
+def with_raw_evidences(*from_evidences):
     """
     Decorate a typical ``test_`` check method processing raw evidences.
 
-    Use when processing raw evidence by a check and the name(s) of the evidence
-    is/are static/known.  When the evidence names are dynamic use the
+    Use when processing raw evidence by a check and the name(s) of the
+    evidence is/are static/known.  When the evidence names are dynamic use the
     ``evidences`` context manager instead.
 
-    :param evidence_paths: relative paths to evidences required by the check.
-      E.g. ``source1/evidence.json`` (this would point to
-      ``raw/source1/evidence.json``).
+    :param from_evidences: relative paths to evidences as strings or
+      FromEvidence namedtuples that contain relative paths to evidences and
+      evidence classes required by the check.
     """
 
     def decorator(f):
-        return _with_evidence_decorator(evidence_paths, f, 'raw')
+        return _with_evidence_decorator(from_evidences, f, 'raw')
 
     return decorator
 
 
-def with_external_evidences(*evidence_paths):
+def with_external_evidences(*from_evidences):
     """
     Decorate a typical ``test_`` check method processing external evidences.
 
@@ -710,19 +768,19 @@ def with_external_evidences(*evidence_paths):
     evidence is/are static/known.  When the evidence names are dynamic use the
     ``evidences`` context manager instead.
 
-    :param evidence_paths: relative paths to evidences required by the check.
-      E.g. ``source1/evidence.json`` (this would point to
-      ``external/source1/evidence.json``).
+    :param from_evidences: relative paths to evidences as strings or
+      FromEvidence namedtuples that contain relative paths to evidences and
+      evidence classes required by the check.
     """
 
     def decorator(f):
-        return _with_evidence_decorator(evidence_paths, f, 'external')
+        return _with_evidence_decorator(from_evidences, f, 'external')
 
     return decorator
 
 
 @deprecated(reason='Decorator to be removed, use with_raw_evidences instead')
-def with_derived_evidences(*evidence_paths):
+def with_derived_evidences(*from_evidences):
     """
     Decorate a typical ``test_`` check method processing temporary evidences.
 
@@ -730,19 +788,19 @@ def with_derived_evidences(*evidence_paths):
     evidence is/are static/known.  When the evidence names are dynamic use the
     ``evidences`` context manager instead.
 
-    :param evidence_paths: relative paths to evidences required by the check.
-      E.g. ``source1/evidence.json`` (this would point to
-      ``derived/source1/evidence.json``).
+    :param from_evidences: relative paths to evidences as strings or
+      FromEvidence namedtuples that contain relative paths to evidences and
+      evidence classes required by the check.
     """
 
     def decorator(f):
-        return _with_evidence_decorator(evidence_paths, f, 'derived')
+        return _with_evidence_decorator(from_evidences, f, 'derived')
 
     return decorator
 
 
 @deprecated(reason='Decorator to be removed')
-def with_tmp_evidences(*evidence_paths):
+def with_tmp_evidences(*from_evidences):
     """
     Decorate a typical ``test_`` check method processing derived evidences.
 
@@ -750,13 +808,13 @@ def with_tmp_evidences(*evidence_paths):
     evidence is/are static/known.  When the evidence names are dynamic use the
     ``evidences`` context manager instead.
 
-    :param evidence_paths: relative paths to evidences required by the check.
-      E.g. ``source1/evidence.json`` (this would point to
-      ``tmp/source1/evidence.json``).
+    :param from_evidences: relative paths to evidences as strings or
+      FromEvidence namedtuples that contain relative paths to evidences and
+      evidence classes required by the check.
     """
 
     def decorator(f):
-        return _with_evidence_decorator(evidence_paths, f, 'tmp')
+        return _with_evidence_decorator(from_evidences, f, 'tmp')
 
     return decorator
 
@@ -773,26 +831,39 @@ def _store_wrapper(self, evidence_path, func, type_name):
     self.locker.add_evidence(evidence)
 
 
-def _with_evidence_decorator(evidence_paths, f, type_str):
+def _with_evidence_decorator(from_evidences, f, type_str):
     prefix = f'{type_str}/'
-    paths = map(
-        lambda p: (prefix + p) if not p.startswith(prefix) else p,
-        evidence_paths
-    )
+    from_evs = []
+    for from_ev in from_evidences:
+        path = from_ev
+        ev_class = None
+        if isinstance(from_ev, FromEvidence):
+            path = from_ev.path
+            if issubclass(from_ev.ev_class, get_evidence_class(type_str)):
+                ev_class = from_ev.ev_class
+        if not path.startswith(prefix):
+            path = f'{prefix}{path}'
+        if not ev_class:
+            ev_class = get_evidence_class(type_str)
+        from_evs.append(FromEvidence(path, ev_class))
+
     if hasattr(f, 'args'):
-        f.args.extend(list(paths))
+        f.args.extend(from_evs)
         return f
 
     @wraps(f)  # required for preserving the function context
     def wrapper(self, *args, **kwargs):
         return _evidence_wrapper(self, wrapper.args, f)
 
-    wrapper.args = list(paths)
+    wrapper.args = from_evs
     return wrapper
 
 
-def _evidence_wrapper(self, evidence_paths, func):
-    evidences = [get_evidence_by_path(p, self.locker) for p in evidence_paths]
+def _evidence_wrapper(self, from_evidences, func):
+    evidences = [
+        fe.ev_class.from_evidence(get_evidence_by_path(fe.path, self.locker))
+        for fe in from_evidences
+    ]
     for evidence in evidences:
         self.add_evidence_metadata(evidence.path)
     return func(self, *evidences)

--- a/doc-source/design-principles.rst
+++ b/doc-source/design-principles.rst
@@ -271,18 +271,27 @@ we've provided some helpful decorators and context managers that validate
 ``ttl`` for you and will ``ERROR`` the check if evidence ``ttl`` has expired
 prior to executing the check's logic.
 
-* ``with_raw_evidences`` decorator: Use this decorator on your check method
-  when you know the full path and name of your raw evidences.  The decorator
-  takes as arguments, the paths to your raw evidences as strings.  It also
-  passes the raw evidences to the decorated method in the form of method
-  arguments.
+* ``with_raw_evidences``, ``with_external_evidences`` decorators: Use these
+  decorators on your check method when you know the full path and name of
+  your raw or external evidences.  Each decorator takes as arguments, the
+  paths to your raw or external evidences as strings or as ``FromEvidence``
+  named tuples.  ``FromEvidence`` has ``path`` and ``ev_class`` (evidence class)
+  as attributes.  If the requested evidences pass TTL validation the evidences
+  are then passed along to the decorated method in the form of method arguments.
+  Use ``FromEvidence`` when dealing with sub-classed ``RawEvidence`` or
+  ``ExternalEvidence``, and you want the evidence provided to the decorated
+  method to be cast as that sub-classed evidence otherwise use a string path
+  and the evidence will be provided as either ``RawEvidence`` or ``ExternalEvidence``.
 
 ``@with_*_evidences`` usage example::
 
   ...
-  from compliance.evidence import with_raw_evidences
+  from compliance.evidence import FromEvidence, with_raw_evidences
   ...
-  @with_raw_evidence('foo/evidence_bar.json', 'foo/evidence_baz.json')
+  @with_raw_evidence(
+      FromEvidence('foo/evidence_bar.json', BarEvidence),
+      'foo/evidence_baz.json'
+  )
   test_bar_vs_baz(self, bar_evidence, baz_evidence):
       # Check code only executes if evidence is not stale.
       # Perform your check logic
@@ -296,33 +305,38 @@ prior to executing the check's logic.
   based on a dynamic set of configurable values.  In other words the full name
   and content of the evidences are based on a configuration and not known prior
   to execution of the check logic.  The context manager takes as arguments, the
-  check (self) object and evidence paths.  The evidence paths can be in the
-  form of a list of paths as strings, a dictionary of key/values pairs as
-  strings where the key is an evidence short name and the value is the evidence
-  path, or simply a single evidence path as a string.  The context manager
+  check (``self``) object and either evidence paths strings or ``FromEvidence``
+  named tuples.  ``FromEvidence`` has ``path`` and ``ev_class`` (evidence class)
+  as attributes.  The evidence arguments can be in the form of a list of paths
+  as strings or ``FromEvidence`` named tuples, a dictionary of key/values pairs
+  where the key is an evidence short name and the value is the evidence
+  path as a string or a ``FromEvidence`` named tuple, or simply a single evidence
+  path as a string or ``FromEvidence`` named tuple.  The context manager
   yields a dictionary containing the evidences as the dictionary values if a
-  list or dictionary or evidence paths are provided and yields an evidence
-  object if a single evidence path as a string is provided.  When a dictionary
-  is yielded by the context manager, the evidence key is its evidence path if a
-  list of evidence paths were provided or its evidence short name if a
-  dictionary of evidence paths were provided.
+  list or dictionary of evidence paths or ``FromEvidence`` named tuples are
+  provided and yields an evidence object if a single evidence path as a string
+  or ``FromEvidence`` named tuple is provided.  When a dictionary is yielded by
+  the context manager, the evidence key is its evidence path if a list of
+  evidence paths or ``FromEvidence`` named tuples were provided or its evidence
+  short name if a dictionary of evidence paths or ``FromEvidence`` named tuples
+  were provided.
 
 ``with evidences`` (list provided) usage example::
 
   ...
-  from compliance.evidence import evidences
+  from compliance.evidence import FromEvidence, evidences
   ...
   test_bar_vs_baz(self):
       for system in systems:
           evidence_paths = [
-              'raw/foo/evidence_bar.json',
+              FromEvidence('foo/evidence_bar.json', BarEvidence),
               'raw/foo/evidence_baz.json'
           ]
           with evidences(self, evidence_paths) as evidences:
               # Check code only executes if evidence is not stale.
               # Perform your check logic
               failures, warnings, successes = self._do_whatever(
-                  evidences['raw/foo/evidence_bar.json'],
+                  evidences['foo/evidence_bar.json'],
                   evidences['raw/foo/evidence_baz.json']
               )
               self.add_failures('bar vs. baz', failures)
@@ -332,12 +346,12 @@ prior to executing the check's logic.
 ``with evidences`` (dictionary provided) usage example::
 
   ...
-  from compliance.evidence import evidences
+  from compliance.evidence import FromEvidence, evidences
   ...
   test_bar_vs_baz(self):
       for system in systems:
           evidence_paths = {
-              'bar': 'raw/foo/evidence_bar.json',
+              'bar': FromEvidence('foo/evidence_bar.json', BarEvidence),
               'baz': 'raw/foo/evidence_baz.json'
           }
           with evidences(self, evidence_paths) as evidences:
@@ -360,6 +374,22 @@ prior to executing the check's logic.
       for system in systems:
           evidence_path = 'raw/foo/evidence_bar.json'
           with evidences(self, evidence_path) as evidence:
+              # Check code only executes if evidence is not stale.
+              # Perform your check logic
+              failures, warnings, successes = self._do_whatever(evidence)
+              self.add_failures('bar stuff', failures)
+              self.add_warnings('bar stuff', warnings)
+              self.add_successes('bar stuff', successes)
+
+``with evidences`` (``FromEvidence`` provided) usage example::
+
+  ...
+  from compliance.evidence import FromEvidence, evidences
+  ...
+  test_bar_stuff(self):
+      for system in systems:
+          from_evidence = FromEvidence('foo/evidence_bar.json', BarEvidence)
+          with evidences(self, from_evidence) as evidence:
               # Check code only executes if evidence is not stale.
               # Perform your check logic
               failures, warnings, successes = self._do_whatever(evidence)

--- a/doc-source/design-principles.rst
+++ b/doc-source/design-principles.rst
@@ -274,28 +274,34 @@ prior to executing the check's logic.
 * ``with_raw_evidences``, ``with_external_evidences`` decorators: Use these
   decorators on your check method when you know the full path and name of
   your raw or external evidences.  Each decorator takes as arguments, the
-  paths to your raw or external evidences as strings or as ``FromEvidence``
-  named tuples.  ``FromEvidence`` has ``path`` and ``ev_class`` (evidence class)
-  as attributes.  If the requested evidences pass TTL validation the evidences
-  are then passed along to the decorated method in the form of method arguments.
-  Use ``FromEvidence`` when dealing with sub-classed ``RawEvidence`` or
-  ``ExternalEvidence``, and you want the evidence provided to the decorated
-  method to be cast as that sub-classed evidence otherwise use a string path
-  and the evidence will be provided as either ``RawEvidence`` or ``ExternalEvidence``.
+  paths to your raw or external evidences as strings or as evidence
+  ``LazyLoader`` named tuples.  Evidence ``LazyLoader`` has ``path`` and
+  ``ev_class`` (evidence class) as attributes.  If the requested evidences pass
+  TTL validation the evidences are then passed along to the decorated method in
+  the form of method arguments.  Use an evidence ``LazyLoader`` when dealing
+  with sub-classed ``RawEvidence`` or ``ExternalEvidence``, and you want the
+  evidence provided to the decorated method to be cast as that sub-classed
+  evidence otherwise use a string path and the evidence will be provided as
+  either ``RawEvidence`` or ``ExternalEvidence``.  A ``LazyLoader`` named tuple
+  can be constructed by executing the ``lazy_load`` class method of any evidence
+  class such as ``BarEvidence.lazy_load('foo/evidence_bar.json')``.
 
 ``@with_*_evidences`` usage example::
 
   ...
-  from compliance.evidence import FromEvidence, with_raw_evidences
+  from compliance.evidence import with_raw_evidences
+  from my_pkg.bar_evidence import BarEvidence
   ...
   @with_raw_evidence(
-      FromEvidence('foo/evidence_bar.json', BarEvidence),
+      BarEvidence.lazy_load('foo/evidence_bar.json'),
       'foo/evidence_baz.json'
   )
   test_bar_vs_baz(self, bar_evidence, baz_evidence):
       # Check code only executes if evidence is not stale.
       # Perform your check logic
-      failures, warnings, successes = self._do_whatever(bar_evidence, baz_evidence)
+      failures, warnings, successes = self._do_whatever(
+          bar_evidence, baz_evidence
+      )
       self.add_failures('bar vs. baz', failures)
       self.add_warnings('bar vs. baz', warnings)
       self.add_successes('bar vs. baz', successes)
@@ -305,31 +311,34 @@ prior to executing the check's logic.
   based on a dynamic set of configurable values.  In other words the full name
   and content of the evidences are based on a configuration and not known prior
   to execution of the check logic.  The context manager takes as arguments, the
-  check (``self``) object and either evidence paths strings or ``FromEvidence``
-  named tuples.  ``FromEvidence`` has ``path`` and ``ev_class`` (evidence class)
-  as attributes.  The evidence arguments can be in the form of a list of paths
-  as strings or ``FromEvidence`` named tuples, a dictionary of key/values pairs
-  where the key is an evidence short name and the value is the evidence
-  path as a string or a ``FromEvidence`` named tuple, or simply a single evidence
-  path as a string or ``FromEvidence`` named tuple.  The context manager
+  check (``self``) object and either evidence paths strings or ``LazyLoader``
+  named tuples.  Evidence ``LazyLoader`` has ``path`` and ``ev_class``
+  (evidence class) as attributes.  The evidence arguments can be in the form of
+  a list of paths as strings or ``LazyLoader`` named tuples, a dictionary of
+  key/values pairs where the key is an evidence short name and the value is the
+  evidence path as a string or a ``LazyLoader`` named tuple, or simply a single
+  evidence path as a string or ``LazyLoader`` named tuple.  The context manager
   yields a dictionary containing the evidences as the dictionary values if a
-  list or dictionary of evidence paths or ``FromEvidence`` named tuples are
+  list or dictionary of evidence paths or ``LazyLoader`` named tuples are
   provided and yields an evidence object if a single evidence path as a string
-  or ``FromEvidence`` named tuple is provided.  When a dictionary is yielded by
+  or ``LazyLoader`` named tuple is provided.  When a dictionary is yielded by
   the context manager, the evidence key is its evidence path if a list of
-  evidence paths or ``FromEvidence`` named tuples were provided or its evidence
-  short name if a dictionary of evidence paths or ``FromEvidence`` named tuples
-  were provided.
+  evidence paths or ``LazyLoader`` named tuples were provided or its evidence
+  short name if a dictionary of evidence paths or ``LazyLoader`` named tuples
+  were provided.  A ``LazyLoader`` named tuple can be constructed by executing
+  the ``lazy_load`` class method of any evidence class such as
+  ``BarEvidence.lazy_load('foo/evidence_bar.json')``.
 
 ``with evidences`` (list provided) usage example::
 
   ...
-  from compliance.evidence import FromEvidence, evidences
+  from compliance.evidence import evidences
+  from my_pkg.bar_evidence import BarEvidence
   ...
   test_bar_vs_baz(self):
       for system in systems:
           evidence_paths = [
-              FromEvidence('foo/evidence_bar.json', BarEvidence),
+              BarEvidence.lazy_load('foo/evidence_bar.json'),
               'raw/foo/evidence_baz.json'
           ]
           with evidences(self, evidence_paths) as evidences:
@@ -346,12 +355,13 @@ prior to executing the check's logic.
 ``with evidences`` (dictionary provided) usage example::
 
   ...
-  from compliance.evidence import FromEvidence, evidences
+  from compliance.evidence import evidences
+  from my_pkg.bar_evidence import BarEvidence
   ...
   test_bar_vs_baz(self):
       for system in systems:
           evidence_paths = {
-              'bar': FromEvidence('foo/evidence_bar.json', BarEvidence),
+              'bar': BarEvidence.lazy_load('foo/evidence_bar.json'),
               'baz': 'raw/foo/evidence_baz.json'
           }
           with evidences(self, evidence_paths) as evidences:
@@ -381,15 +391,16 @@ prior to executing the check's logic.
               self.add_warnings('bar stuff', warnings)
               self.add_successes('bar stuff', successes)
 
-``with evidences`` (``FromEvidence`` provided) usage example::
+``with evidences`` (``LazyLoader`` provided) usage example::
 
   ...
-  from compliance.evidence import FromEvidence, evidences
+  from compliance.evidence import evidences
+  from my_pkg.bar_evidence import BarEvidence
   ...
   test_bar_stuff(self):
       for system in systems:
-          from_evidence = FromEvidence('foo/evidence_bar.json', BarEvidence)
-          with evidences(self, from_evidence) as evidence:
+          lazy_evidence = BarEvidence.lazy_load('foo/evidence_bar.json')
+          with evidences(self, lazy_evidence) as evidence:
               # Check code only executes if evidence is not stale.
               # Perform your check logic
               failures, warnings, successes = self._do_whatever(evidence)

--- a/doc-source/evidence-partitioning.rst
+++ b/doc-source/evidence-partitioning.rst
@@ -131,20 +131,20 @@ Default Partition Root
 
 * Partitions yielded
 
-  * US/IL partition - ``foo/<us_il_hash>_evidence.bar.json``::
+  * US/IL partition - ``foo/<us_il_hash>_evidence_bar.json``::
 
       [
         {"foo": "...", "bar": "...", "country": "US", "region": "IL"},
         {"foo": "...", "bar": "...", "country": "US", "region": "IL"}
       ]
 
-  * US/NY partition - ``foo/<us_ny_hash>_evidence.bar.json``::
+  * US/NY partition - ``foo/<us_ny_hash>_evidence_bar.json``::
 
       [
         {"foo": "...", "bar": "...", "country": "US", "region": "NY"}
       ]
 
-  * UK/Essex partition - ``foo/<uk_essex_hash>_evidence.bar.json``::
+  * UK/Essex partition - ``foo/<uk_essex_hash>_evidence_bar.json``::
 
       [
         {"foo": "...", "bar": "...", "country": "UK", "region": "Essex"},

--- a/doc-source/running-on-travis.rst
+++ b/doc-source/running-on-travis.rst
@@ -56,7 +56,7 @@ This is a typical `.travis.yml` file:
    python:
      - "3.7"
    install:
-     - pip -r requirements.txt
+     - pip install -r requirements.txt
      - ./travis/gen-credentials.py > ~/.credentials
    script:
      - make clean
@@ -64,9 +64,9 @@ This is a typical `.travis.yml` file:
    after_script:
      - rm  ~/.credentials
 
-Basically, this will firstly install the dependencies through ``pip -r
-requirements.txt`` and then generate the credentials file from using
-Travis environment variables.
+Basically, this will firstly install the dependencies through
+``pip install -r requirements.txt`` and then generate the credentials file from
+using Travis environment variables.
 
 Credentials generation
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Add support for check decorators and context manager to return subclassed framework evidence objects.
- Replace os.path with pathlib.PurePath in the evidences module
- Add a content_as_json property to evidence base class

## Why

- The act of casting of subclassed raw or external evidence should be handled by the framework instead of having to be handled by individual check logic.
- Using PurePath or Path from pathlib whenever possible over os.path is a cleaner more generic solution.
- Adding content_as_json is also helpful and a common enough need that it should be contained within the framework for evidences with JSON content

## How

- Add FromEvidence named tuple
- Add passing FromEvidence to with_*_evidences decorators
- Add passing FromEvidence to evidences context manager
- Replace os.path usage with pathlib.PurePath
- Updated docs

## Test

- Present behavior of `with_*_evidences` decorators and `evidences` context manager is preserved
- Passing a combination of FromEvidence named tuples and string paths to decorators and context manager yields the expected results for evidences returned.  Evidences specified as FromEvidence are returned to the `test_` function/method as the evidence specified as the `ev_class` otherwise the evidence is returned as either raw or external as appropriate.

## Context

N/A
