### PR TITLE
Fix evidence cast bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.7.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.7.1)
+
+- [FIXED] Subclassed evidence support works with cached evidence now.
+
 # [1.7.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.7.0)
 
 - [ADDED] Check evidence decorators and context manager now support subclassed evidence.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.7.0'
+__version__ = '1.7.1'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix evidence cast bug that wasn't working with the evidence cache correctly

## Why

Evidence in the cache should override casting evidence by decorators and context manager

## How

Check for cast evidence returned from the locker

## Test

- Bug fixed in internal repo tests
- New functionality also still works as expected

## Context

N/A
