### PR TITLE
Remove LazyLoader defaults for 3.6 compatibility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.7.2](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.7.2)
+
+- [FIXED] LazyLoader namedtuple defaults removed; Framework compatible with Python 3.6 again.
+
 # [1.7.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.7.1)
 
 - [FIXED] Subclassed evidence support works with cached evidence now.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.7.1'
+__version__ = '1.7.2'

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -37,7 +37,7 @@ HOUR = 60 * 60
 DAY = HOUR * 24
 YEAR = DAY * 365
 
-LazyLoader = namedtuple('LazyLoader', 'path ev_class', defaults=[None])
+LazyLoader = namedtuple('LazyLoader', 'path ev_class')
 
 
 class _BaseEvidence(object):


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Remove LazyLoader defaults...

## Why

...for 3.6 compatibility

## How

Remove LazyLoader defaults

## Test

- Unit tests run successfully in 3.8
- Unit tests run successfully in 3.6

## Context

Fixes #82 
