### PR TITLE
Add selective bulk fetcher execution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.8.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.8.0)
+
+- [ADDED] Selective fetcher bulk `--include` and `--exclude` execution is now possible.
+
 # [1.7.2](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.7.2)
 
 - [FIXED] LazyLoader namedtuple defaults removed; Framework compatible with Python 3.6 again.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.7.2'
+__version__ = '1.8.0'

--- a/compliance/runners.py
+++ b/compliance/runners.py
@@ -15,6 +15,7 @@
 """Compliance automation flow management module."""
 
 import inspect
+import json
 import os
 import re
 import sys
@@ -180,7 +181,16 @@ class FetchMode(_BaseRunner):
                         self.load_errors.add(load_err)
                 except AttributeError:
                     pass
-        return fetchers
+        include = {f'{f.__module__}.{f.__name__}' for f in fetchers}
+        if self.opts.include:
+            include = set(json.loads(open(self.opts.include).read()))
+        exclude = set()
+        if self.opts.exclude:
+            exclude = set(json.loads(open(self.opts.exclude).read()))
+        return filter(
+            lambda f: f'{f.__module__}.{f.__name__}' in include - exclude,
+            fetchers
+        )
 
     def run_fetchers(self, reruns=None):
         """

--- a/compliance/runners.py
+++ b/compliance/runners.py
@@ -181,6 +181,8 @@ class FetchMode(_BaseRunner):
                         self.load_errors.add(load_err)
                 except AttributeError:
                     pass
+        if not (self.opts.include or self.opts.exclude):
+            return fetchers
         include = {f'{f.__module__}.{f.__name__}' for f in fetchers}
         if self.opts.include:
             include = set(json.loads(open(self.opts.include).read()))

--- a/compliance/scripts/compliance_cli.py
+++ b/compliance/scripts/compliance_cli.py
@@ -107,6 +107,18 @@ class ComplianceCLI(Command):
             action='append',
             default=[]
         )
+        self.add_argument(
+            '--include',
+            help='Specifies the path/name of the fetcher include JSON file.',
+            metavar='fetchers.json',
+            default=None
+        )
+        self.add_argument(
+            '--exclude',
+            help='Specifies the path/name of the fetcher exclude JSON file.',
+            metavar='fetchers.json',
+            default=None
+        )
 
     def _validate_arguments(self, args):
         if 'stdout' not in args.notify:
@@ -117,6 +129,10 @@ class ComplianceCLI(Command):
             )
         if not args.fetch and not args.check:
             self.parser.error('--fetch or --check option is expected.')
+        if not args.fetch and (args.include or args.exclude):
+            self.parser.error(
+                '--include/--exclude options only valid with --fetch.'
+            )
         if not args.check and args.fix != 'off':
             self.parser.error('--fix option only valid with --check.')
 

--- a/doc-source/design-principles.rst
+++ b/doc-source/design-principles.rst
@@ -235,9 +235,20 @@ due to an unavailable evidence dependency.
 Fetcher Execution
 =================
 
-The Auditree framework will run all fetchers (tests prefixed by ``fetch_``)
-that it can find.
+By default the Auditree framework will run all fetchers (tests prefixed by
+``fetch_``) that it can find.  However, it is possible to limit fetcher
+execution in bulk by using the ``--include`` and/or ``exclude`` CLI options
+while providing a file path/name to a JSON config file containing a list of
+fetchers to include/exclude.  The format of the JSON config file is a list of
+fetcher classes.  Where a fetcher class is represented as a string dot notation
+path to the fetcher class.
 
+Fetcher include/exclude JSON config file example::
+
+  [
+    "fetcher_pkg.path_to_my_checks.checks.fetch_module_foo.FooFetcherClass",
+    "fetcher_pkg.path_to_my_checks.checks.fetch_module_bar.BarFetcherClass"
+  ]
 
 Compliance Checks
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add selective bulk fetcher execution

## Why

In cases where we want to target fetcher executions to a set of fetchers rather than the entire set of fetchers in the execution repo.

## How

- Filter the list of all fetchers found with the fetchers provided in the fetcher include/exclude config file(s).
- Docs added to design principals RST

## Test

- Current functionality of all fetchers executed when no include/exclude options provided is preserved.
- When only `--exclude` is used: Excludes only specified fetchers
- When only `--include` is used: Includes only specified fetchers
- When both are used: Excludes specified fetchers from the list include specified fetchers

## Context

Closes #84 
