### PR TITLE
Add pagination capability to github issue comments api (#90)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.9.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.9.1)
+
+- [FIXED] Github service `Github.get_issue_comments` returns all issue comments now.
+
 # [1.9.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.9.0)
 
 - [ADDED] Storing raw evidence as binary content is now possible.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.9.0'
+__version__ = '1.9.1'

--- a/compliance/utils/services/github.py
+++ b/compliance/utils/services/github.py
@@ -231,8 +231,7 @@ class Github(object):
 
     def get_issue_comments(self, owner, repo, issue, parse_annotations=False):
         """Retrieve a repository issue's comments."""
-        comments = self._make_request(
-            'get',
+        comments = self._paginate_api(
             '/'.join(['repos', owner, repo, 'issues', str(issue), 'comments'])
         )
         if parse_annotations:


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

This pull request is to enable pagination in Github issue comments API.

## Why

Current github API only fetches comments that fit within the first page of the response

## How

   - Replace `_make_request()` call with `_paginate_api()` call in `get_issue_comments()`

## Test

Tested with some issues with a large number (>30) of comments.

## Context

Closes #90 
