### PR TITLE
Create GitHub Issues from a subset of checks.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.10.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.10.0)
+
+- [CHANGED] GitHub Issues notifier can create issues for a subset of an accreditation's checks with a new configuration element.
+
 # [1.9.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.9.1)
 
 - [FIXED] Github service `Github.get_issue_comments` returns all issue comments now.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.9.1'
+__version__ = '1.10.0'

--- a/compliance/notify.py
+++ b/compliance/notify.py
@@ -552,6 +552,12 @@ class GHIssuesNotifier(_BaseMDNotifier):
         if not results:
             return issues
         for check_path, result, message in results:
+            # If the 'checks' configuration element exists
+            # within an accreditation, only create issues
+            # for the set of checks therein.
+            if ('checks' in self._config[accred].keys()
+                    and check_path not in self._config[accred]['checks']):
+                continue
             now = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
             body = [f'## Compliance check alert - {now}']
             body.append(f'- Check: {check_path}')

--- a/doc-source/notifiers.rst
+++ b/doc-source/notifiers.rst
@@ -298,11 +298,13 @@ list of projects boards and project columns to add the notification issues to.
 To specify a repository provide the GitHub "owner" and "repository"
 in the form of ``owner/repository``.  Valid status values include "pass",
 "warn", "fail", and "error".  If no status configuration is provided then the
-"fail" status is used as the default.  Finally to specify project boards to
-assign issues to, set "project" to a dictionary where the keys are
-project names and the values are the column names.  The following is an example
-configuration for this notifier to be added to a configuration file and used
-with the ``-C`` option when executing your compliance checks::
+"fail" status is used as the default.  You can also optionally limit your
+notifications to a set of checks within an accreditation by providing a list
+of check paths with a "checks" list. Finally to specify project boards to
+assign issues to, set "project" to a dictionary where the keys are project
+names and the values are the column names.  The following is an example
+configuration for this notifier to be added to a configuration file and
+used with the ``-C`` option when executing your compliance checks::
 
   {
     "notify": {
@@ -315,7 +317,11 @@ with the ``-C`` option when executing your compliance checks::
         "accr2": {
           "repo": ["my-org/accr2-repo"],
           "project": {"Some other super cool project": "Backlog"},
-          "status": ["error"]
+          "status": ["error"],
+          "checks": [
+            "chk_pkg.chk_cat_foo.checks.chk_module_foo.FooCheckClass",
+            "chk_pkg.chk_cat_foo.checks.chk_module_bar.BarCheckClass"
+          ]
         }
       }
     }


### PR DESCRIPTION
- Adds logic to `GHIssuesNotifier._generate_issues` that
  looks for a `checks` configuration element.

- If the configuration element is found with a value,
  only generate GitHub issues based on any checks
  contained therein.

- Increments version where applicable as I'd like
  to use the changes ASAP.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Adds logic to allow GitHub Issue notifications based on a subset of checks in a given accreditation.

## Why

- Not all checks in a given accreditation necessarily need separate GitHub Issues created for them.

## How

- Add logic to GHIssuesNotifier.__generate_issues to look for a non-empty checks configuration element within a given accreditation and then only generate issues for the specified checks if it's found.

## Test

- Manually tested it against GitHub project to make sure it created a card and/or updated an existing issue.

## Context

- Closes #93 
- Closes #37 