### PR TITLE
Add full-remote push for fetcher execution

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.11.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.11.0)
+
+- [ADDED] Fetcher execution using `--evidence full-remote` mode pushes to remote locker now.
+
 # [1.10.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.10.1)
 
 - [FIXED] Reading raw evidence in checks is now supported.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.10.1'
+__version__ = '1.11.0'

--- a/compliance/locker.py
+++ b/compliance/locker.py
@@ -578,10 +578,16 @@ class Locker(object):
     def push(self):
         """Push the local git repository to the remote repository."""
         if self._do_push:
+            remote = self.repo.remote()
+            self.logger.info(
+                f'Syncing local locker with remote repo {self.repo_url}...'
+            )
+            remote.fetch()
+            remote.pull(rebase=True)
             self.logger.info(
                 f'Pushing local locker to remote repo {self.repo_url}...'
             )
-            push_info = self.repo.remotes[0].push()[0]
+            push_info = remote.push()[0]
             if push_info.flags >= git.remote.PushInfo.ERROR:
                 raise LockerPushError(push_info)
 

--- a/compliance/runners.py
+++ b/compliance/runners.py
@@ -159,6 +159,13 @@ class FetchMode(_BaseRunner):
         super(FetchMode, self).__exit__(typ, val, traceback)
         # make sure that all added evidence are committed
         self.locker.checkin()
+        # Only push if fetchers are run separately from checks,
+        # otherwise push occurs after check processing is complete.
+        if not self.opts.check:
+            try:
+                self.locker.push()
+            except LockerPushError as lpe:
+                self.locker.logger.error(str(lpe))
 
     def get_fetchers(self):
         """Provide all compliance framework fetcher classes."""

--- a/compliance/scripts/compliance_cli.py
+++ b/compliance/scripts/compliance_cli.py
@@ -149,11 +149,6 @@ class ComplianceCLI(Command):
     def _run(self, args):
         success = True
         if args.fetch:
-            if args.evidence == 'full-remote':
-                self.out(
-                    'INFO: A remote locker sync will only occur '
-                    'after checks are executed in full-remote mode.'
-                )
             with FetchMode(args, self.extra_args) as fetch:
                 # Handle fetcher primary run.
                 self.out('\nFetcher Primary Run\n')

--- a/doc-source/quick-start.rst
+++ b/doc-source/quick-start.rst
@@ -84,27 +84,35 @@ Using ``github`` as an example, add the following to your credentials file::
   token=XXX
 
 Once the credentials are set up, you can run fetchers and checks in ``no-push``
-or ``full-remote`` mode::
-
-  $ compliance --fetch --evidence no-push -C auditree_demo.json
+or ``full-remote`` mode.
 
 For a fetcher execution the Auditree framework will ``pull`` the repository to
 ``/$TMPDIR/compliance`` (only if it does not exist already), and then run all
 of the fetchers.  If evidence time to live (TTL) has not expired for a given
-evidence file then the associated fetcher will perform a no-op run.  It is
-important to note that nothing will be pushed at the end of a fetcher execution
-regardless of the ``--evidence`` option used.  This is handy for testing the
-current state of the evidence in your remote evidence locker.
+evidence file then the associated fetcher will perform a no-op run.
+
+It is important to note that when using the ``no-push`` option, your evidence
+locker will not be pushed to the remote evidence locker at the end of your fetcher
+execution.  This is handy for testing the current state of the evidence in your
+evidence locker::
+
+  $ compliance --fetch --evidence no-push -C auditree_demo.json
+
+However using the ``full-remote`` option will push your evidence locker to the
+remote locker::
+
+  $ compliance --fetch --evidence full-remote -C auditree_demo.json
 
 Likewise once the credentials are set up and you've executed your fetchers in
-either ``no-push`` or ``full-remote`` mode.  To execute checks in ``no-push``
-mode which will not push the evidence locker to the remote evidence locker::
+either ``no-push`` or ``full-remote`` mode you can now execute your checks in
+``no-push`` mode which will not push the evidence locker to the remote evidence
+locker::
 
   $ compliance --check demo.arboretum.accred,demo.custom.accred --evidence no-push -C auditree_demo.json
 
 
-To execute checks in ``full-remote`` mode which will push the evidence locker to
-the remote evidence locker::
+However using the ``full-remote`` option will push your evidence locker to the
+remote locker::
 
   $ compliance --check demo.arboretum.accred,demo.custom.accred --evidence full-remote -C auditree_demo.json
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add full-remote push functionality for fetcher execution

## Why

Adding the ability to push after fetcher executions provides execution flexibility and it clarifies the `--evidence full-remote` option.

## How

- Add syncing operation prior to push (`git fetch` and `git pull --rebase` are performed)
- Locker.push() is called at the end of a fetcher execution
- Docs updated
- Appropriate logging added/removed

## Test

- Fetch push works
- Sync functionality also works as part of the push
- Check push and sync also work

## Context

Closes #36 
