### PR TITLE
Add support for retrieving evidence from a previous locker

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# [1.12.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.12.0)
+
+- [ADDED] Referencing historical evidence from a previous locker is now supported.
+- [ADDED] The optional `locker.prev_repo_url` configuration element was added.
+- [ADDED] Evidence used by checks found in reports metadata includes the locker URL field now.
+- [ADDED] Links to evidence used by checks found in the table of contents point to the appropriate lockers.
+- [ADDED] Evidence used by checks found in check_results.json includes the locker URL field now.
+
 # [1.11.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.11.0)
 
 - [ADDED] Fetcher execution using `--evidence full-remote` mode pushes to remote locker now.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.11.0'
+__version__ = '1.12.0'

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -794,7 +794,7 @@ def with_external_evidences(*from_evidences):
 @deprecated(reason='Decorator to be removed, use with_raw_evidences instead')
 def with_derived_evidences(*from_evidences):
     """
-    Decorate a typical ``test_`` check method processing temporary evidences.
+    Decorate a typical ``test_`` check method processing derived evidences.
 
     Use when processing derived evidence by a check and the name(s) of the
     evidence is/are static/known.  When the evidence names are dynamic use the
@@ -814,7 +814,7 @@ def with_derived_evidences(*from_evidences):
 @deprecated(reason='Decorator to be removed')
 def with_tmp_evidences(*from_evidences):
     """
-    Decorate a typical ``test_`` check method processing derived evidences.
+    Decorate a typical ``test_`` check method processing temporary evidences.
 
     Use when processing temporary evidence by a check and the name(s) of the
     evidence is/are static/known.  When the evidence names are dynamic use the

--- a/compliance/report.py
+++ b/compliance/report.py
@@ -125,9 +125,10 @@ class ReportBuilder(object):
             for ev in meta.get('evidence', []):
                 ev_path = pathlib.Path(ev['path'])
                 ev_descr = ev['description'] or ev_path.name
+                ev_locker_url = ev.get('locker_url', self.locker.repo_url)
                 if not ev.get('partitions'):
                     ev_url = self.locker.get_remote_location(
-                        ev['path'], False, ev['commit_sha']
+                        ev['path'], False, ev['commit_sha'], ev_locker_url
                     )
                     evidences.append(
                         {
@@ -142,7 +143,8 @@ class ReportBuilder(object):
                         ev_url = self.locker.get_remote_location(
                             str(ev_path.parent / f'{hash_key}_{ev_path.name}'),
                             False,
-                            part['commit_sha']
+                            part['commit_sha'],
+                            ev_locker_url
                         )
                         evidences.append(
                             {

--- a/doc-source/design-principles.rst
+++ b/doc-source/design-principles.rst
@@ -85,7 +85,7 @@ for:
 
   All `git options <https://git-scm.com/docs/git-config>`_ are
   accepted. Set your git configuration with care, paying special
-  attention to those attributes within ``core`` section.
+  attention to those attributes within the ``core`` section.
 
 * Validating the ``ttl`` for a given evidence.  An optional evidence
   ``ttl`` tolerance value can be configured to be applied during
@@ -103,6 +103,28 @@ for:
      "locker": {
        "repo_url": "https://github.com/my-org/my-evidence-repo",
        "ttl_tolerance": 3600
+     }
+   }
+
+* It's generally a good idea to regularly "archive" an evidence locker in
+  favor of a fresh one.  A yearly locker archive/refresh is a good guideline
+  to follow.  However in cases where checks may need to reference historical
+  evidence, using a new locker will cause undesirable results in the short
+  term.  For cases like this referencing historical evidence from a previous
+  locker is possible by using the ``prev_repo_url`` option.  With that
+  option set, a check that is unable to find historical evidence in the
+  current evidence locker will be able to download the previous locker and
+  look for the historical evidence there.  This will continue to do this until
+  the new locker is primed with enough historical evidence to support all
+  checks.  Setting the option in your configuration JSON file would look
+  similar to:
+
+.. code-block:: json
+
+   {
+     "locker": {
+       "repo_url": "https://github.com/my-org/my-evidence-repo",
+       "prev_repo_url": "https://github.com/my-org/my-evidence-repo-old"
      }
    }
 

--- a/test/t_compliance/t_check/test_base_check.py
+++ b/test/t_compliance/t_check/test_base_check.py
@@ -41,6 +41,7 @@ class ComplianceCheckTest(unittest.TestCase):
         # Ensures that the check object has a (mocked) locker attribute/object
         # on it as expected.
         self.check.locker = create_autospec(Locker)
+        self.check.locker.repo_url = 'https://my.locker.url'
 
     def test_title(self):
         """Check title raises an exception in the base class."""
@@ -178,7 +179,8 @@ class ComplianceCheckTest(unittest.TestCase):
                     'path': 'raw/foo/foo.json',
                     'commit_sha': 'mycommitsha',
                     'foo': 'bar',
-                    'last_update': '2019-11-15'
+                    'last_update': '2019-11-15',
+                    'locker_url': 'https://my.locker.url'
                 }
             }
         )
@@ -227,7 +229,8 @@ class ComplianceCheckTest(unittest.TestCase):
                         }
                     },
                     'foo': 'bar',
-                    'last_update': '2019-11-15'
+                    'last_update': '2019-11-15',
+                    'locker_url': 'https://my.locker.url'
                 }
             }
         )


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add support for retrieving evidence from a previous locker.

## Why

To support locker repo archival for checks that need to access historical evidence.

## How

- Update the Locker to retry the initial call to `Locker.get_evidence` when historical evidence is not found
- locker.prev_locker_url config option now available/supported
- Retry occurs only if a previous locker url was provided in the configuration
- Update Locker.get_remote_location to optionally take a locker URL, to be used when returning the appropriate remote location for a piece of evidence
- Reports metadata, check_results.json, and TOC where evidence logging is possible now also includes a `locker_url` field
- Update ComplianceCheck.get_historical_evidence and ComplianceCheck.add_evidence_metadata accordingly to handle the above
- Update ReportBuilder.generate_toc to handle the above
- Design Principles updated

## Test

- Unit tests updated.  All running successfully.
- Tested locally using an empty locker and an archived evidence locker with 3K+ commits
   - Fetcher functionality not impacted
   - Evidence dependency functionality not impacted
   - Checks (python packages and abandoned evidence) pulled newly fetched evidence from the new locker and historical evidence (1 commit) from the previous locker.
   - check_results.json contains the proper commit sha and locker URL in the content for python packages (abandoned evidence does not gather the evidence details in the results currently)
   - reports metadata contains the proper commit sha and locker URL in the content for python packages (abandoned evidence does not gather the evidence details in the results currently)
   - TOC links to evidence in appropriate lockers
- Tested with checks that require 70 days worth of historical evidence and fetchers that leverage dependency chaining.  Results were the same as above

## Context

Closes #101 
