### PR TITLE
Add locker shallow cloning

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.13.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.13.0)
+
+- [ADDED] Configurable shallow cloning of locker is now supported.
+
 # [1.12.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.12.0)
 
 - [ADDED] Referencing historical evidence from a previous locker is now supported.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.12.0'
+__version__ = '1.13.0'

--- a/doc-source/design-principles.rst
+++ b/doc-source/design-principles.rst
@@ -128,6 +128,25 @@ for:
      }
    }
 
+* A locker can grow large, causing CI/CD jobs to run longer than desired
+  due to locker download time.  So in addition to a sound locker archiving
+  strategy, it is also possible to configure your locker to only download
+  recent commits by using the ``shallow_days`` option.  When ``shallow_days``
+  is supplied, only commits since the current date minus the number of days set
+  as ``shallow_days`` are included in the locker download.  The option applies
+  to both the locker and the previous locker (if applicable).  Setting the
+  option in your configuration JSON file would look similar to::
+
+.. code-block:: json
+
+   {
+     "locker": {
+       "repo_url": "https://github.com/my-org/my-evidence-repo",
+       "prev_repo_url": "https://github.com/my-org/my-evidence-repo-old",
+       "shallow_days": 10
+     }
+   }
+
 
 .. _fetchers:
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add locker shallow cloning.

## Why

To provide a smaller locker download.

## How

- Add `locker.shallow_days` option to config.
- Defaults to full locker if not supplied.
- The since date is calculated based on the current UTC datetime minus (the number of days provided plus one).
- Perform a `git clone` using the `--shallow-since` option.

## Test

- Current functionality is not affected.  All works as it once did when no option is provided.
- locker pulls down repo only containing commits since the "since" date.
- previous locker also pulls down repo only containing commits since the "since" date.
- Local locker commits happen as expected.
- Locker push occurs after fetch and check processing as expected.

## Context

Closes #99 
