### PR TITLE
Add filtered content flag and clone logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# [1.14.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.14.0)
+
+- [ADDED] The `filtered_content` attribute has been added to `RawEvidence`.
+- [ADDED] Locker clone duration logging has been added.
+- [FIXED] The `binary_content` attribute on raw evidence is retained as metadata now.
+- [FIXED] All partitioned evidence defined via constructor correctly retains attributes now.
+
 # [1.13.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.13.0)
 
 - [ADDED] Configurable shallow cloning of locker is now supported.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.13.0'
+__version__ = '1.14.0'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Add filtered content flag to raw evidence.
- Add locker clone duration logging.
- Ensure binary content flag persists for binary raw evidence by adding to evidence metadata.

## Why

- Filtered content in raw evidence marks raw evidence that has not been manipulated but filtered in cases when an API returns so much unused content that it makes evidence sizes too large for github to handle.
- It's good to have an idea how long it took the locker to be cloned locally.
- Persisting the binary content flag allows for binary raw evidence to be pulled from the locker and automatically processed by checks as binary content.

## How

- Add filtered_content flag to RawEvidence
- Add writing of filtered_content and binary_content flag to metadata
- Add a duration counter to cloning routine in locker and display as INFO level logging

## Test

- Flags are added to metadata as expected when set to True **only**
- Evidence objects are pulled from the locker with those flags set as attributes appropriately
- Locker clone duration logging displays in the execution log in seconds to complete clone

## Context

Closes #104 
Closes #106 
Closes #109 
