### PR TITLE
Fix evidences context manager when no evidence found

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,13 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.30.0
+    rev: v0.31.0
     hooks:
     -   id: yapf
         args: [--in-place, --parallel, --recursive, --style, .yapf-config]
         files: "^(compliance|test)"
         stages: [commit]
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
     -   id: flake8
         args: [

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.15.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.15.0)
+
+- [FIXED] The evidences context manager now raises an exception when no evidence is found.
+
 # [1.14.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.14.0)
 
 - [ADDED] The `filtered_content` attribute has been added to `RawEvidence`.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.14.0'
+__version__ = '1.15.0'

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -511,6 +511,8 @@ class evidences(object):  # noqa: N801
         if hasattr(self, 'check'):
             for ev_path in evidence_list:
                 self.check.add_evidence_metadata(ev_path)
+        if not evidence:
+            raise EvidenceNotFoundError('No evidence found!')
         return evidence
 
     def __exit__(self, typ, val, traceback):


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix evidences context manager when no evidence found.

## Why

When no evidence can be found by the context manager, it should raise an exception rather than returning an empty dictionary.

## How

Prior to return, raise EvidenceNotFoundError exception if evidence dict is empty.

## Test

- When evidence is found, current functionality is unaffected
- When no evidence is found, EvidenceNotFoundError is raised

## Context

Fixes https://github.com/ComplianceAsCode/auditree-arboretum/issues/61
