### PR TITLE
Add large file logging support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# [1.17.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.17.0)
+
+- [ADDED] Locker get_large_files method added to return large files in the locker.
+- [ADDED] Logging of large files added to remote push operation.
+
 # [1.16.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.16.0)
 
 - [ADDED] Locker get_empty_evidences method added to return all empty evidence paths.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.16.0'
+__version__ = '1.17.0'

--- a/test/t_compliance/t_locker/test_locker.py
+++ b/test/t_compliance/t_locker/test_locker.py
@@ -281,6 +281,25 @@ class LockerTest(unittest.TestCase):
                 ]
             )
 
+    def test_large_files(self):
+        """Test paths to large files are returned."""
+        with Locker(name=REPO_DIR) as locker:
+            large = RawEvidence(
+                'large.txt', 'test_category', DAY, 'Large evidence'
+            )
+            large.set_content('X' * 10000)
+            locker.add_evidence(large)
+            small = RawEvidence(
+                'small.txt', 'test_category', DAY, 'Small evidence'
+            )
+            small.set_content('X' * 10)
+            locker.add_evidence(small)
+            locker.checkin()
+            self.assertEqual(
+                locker.get_large_files(9999),
+                {'raw/test_category/large.txt': 10000}
+            )
+
     def test_add_partitioned_evidence(self):
         """Test that partitioned evidence is added to locker as expected."""
         with Locker(name=REPO_DIR) as locker:


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add large file logging support.

## Why

- When large files exist in git, the remote hosting service may reject them based on varying size requirements.  Logging large files as part of the execution log helps point to possible remote hosting service hook violations.
- Adding a method to identify large files can be used in a check as well.

## How

- Added Locker get_large_files convenience method
- Added logging to Locker push
- Refactored empty and abandoned evidence

## Test

- Abandoned evidence works as before
- Empty evidence works as before
- Logging works when threshold is exceeded
- Large files are returned and threshold is configurable

## Context

Fixes #31 
Fixes #110 
