### PR TITLE
Replace os.path with pathlib and fix TOC bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+# [1.18.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.18.0)
+
+- [CHANGED] Now using `pathlib` exclusively for operating system filepath and file functionality.
+- [FIXED] README table of contents generation multi-blank line bug is resolved.
+
 # [1.17.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.17.0)
 
 - [ADDED] Locker get_large_files method added to return large files in the locker.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.17.0'
+__version__ = '1.18.0'

--- a/compliance/controls.py
+++ b/compliance/controls.py
@@ -17,8 +17,8 @@
 import copy
 import itertools
 import json
-import os
 from collections import defaultdict
+from pathlib import Path
 
 
 class ControlDescriptor(object):
@@ -33,11 +33,11 @@ class ControlDescriptor(object):
         self._controls = {}
         self._paths = []
         for d in dirs or ['.']:
-            json_file = os.path.join(os.path.abspath(d), 'controls.json')
-            if not os.path.isfile(json_file):
+            json_file = Path(d, 'controls.json').resolve()
+            if not json_file.is_file():
                 continue
-            self._controls.update(json.loads(open(json_file).read()))
-            self._paths.append(json_file)
+            self._controls.update(json.loads(json_file.read_text()))
+            self._paths.append(str(json_file))
 
     @property
     def paths(self):

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -103,7 +103,7 @@ class _BaseEvidence(object):
 
     @property
     def dir_path(self):
-        return str(PurePath(self.rootdir).joinpath(self.category))
+        return str(PurePath(self.rootdir, self.category))
 
     @property
     def name(self):
@@ -111,7 +111,7 @@ class _BaseEvidence(object):
 
     @property
     def path(self):
-        return str(PurePath(self.dir_path).joinpath(self.name))
+        return str(PurePath(self.dir_path, self.name))
 
     @property
     def extension(self):

--- a/compliance/fetch.py
+++ b/compliance/fetch.py
@@ -14,10 +14,10 @@
 # limitations under the License.
 """Compliance fetcher automation module."""
 
-import os
 import shutil
 import tempfile
 import unittest
+from pathlib import Path
 
 from compliance.config import get_config
 from compliance.utils.http import BaseSession
@@ -121,10 +121,8 @@ def fetch(url, name):
     """
     r = requests.get(url)
     r.raise_for_status()
-    path = os.path.join(tempfile.gettempdir(), name)
-
-    with open(path, 'wb') as f:
+    path = Path(tempfile.gettempdir(), name)
+    with path.open('wb') as f:
         r.raw.decode_content = True
         shutil.copyfileobj(r.raw, f)
-
     return path

--- a/compliance/notify.py
+++ b/compliance/notify.py
@@ -17,10 +17,10 @@
 import copy
 import json
 import logging
-import os
 import sys
 import time
 from datetime import datetime
+from pathlib import PurePath
 from urllib.parse import urlparse
 
 from compliance.config import get_config
@@ -413,7 +413,7 @@ class LockerNotifier(_BaseMDNotifier):
         )
         self.locker.checkin(
             'Locker notification sent at local time '
-            f'{time.ctime(time.time())}\n\n{os.path.join(folder, filename)}'
+            f'{time.ctime(time.time())}\n\n{PurePath(folder, filename)}'
         )
         self.locker.push()
 

--- a/compliance/utils/credentials.py
+++ b/compliance/utils/credentials.py
@@ -15,9 +15,10 @@
 """Compliance credentials configuration."""
 
 import logging
-import os
 from collections import OrderedDict, namedtuple
 from configparser import RawConfigParser
+from os import environ
+from pathlib import Path
 
 # used to differentiate a user passing None vs
 # not passing a value for an optional argument
@@ -36,7 +37,7 @@ class Config():
         :param cfg_file: The path to the RawConfigParser compatible config file
         """
         self._cfg = RawConfigParser()
-        self._cfg.read(os.path.expanduser(cfg_file))
+        self._cfg.read(str(Path(cfg_file).expanduser()))
         self._cfg_file = cfg_file
 
     def __getitem__(self, section):
@@ -70,13 +71,12 @@ class Config():
                 raise exc
 
         env_vars = [
-            k for k in os.environ.keys()
-            if k.startswith(f'{section.upper()}_')
+            k for k in environ.keys() if k.startswith(f'{section.upper()}_')
         ]
         env_keys = [
             k.split(section.upper())[1].lstrip('_').lower() for k in env_vars
         ]
-        env_values = [os.environ[e] for e in env_vars]
+        env_values = [environ[e] for e in env_vars]
         if env_vars:
             logger.debug(
                 f'Loading credentials from ENV vars: {", ".join(env_vars)}'

--- a/compliance/utils/path.py
+++ b/compliance/utils/path.py
@@ -15,8 +15,8 @@
 """Compliance automation path formatting utilities module."""
 
 import imp
-import os
 import sys
+from pathlib import Path
 
 from compliance.config import get_config
 
@@ -26,45 +26,48 @@ CHECK_PREFIX = 'test_'
 
 def get_toplevel_dirpath(path):
     """
-    Provide the toplevel directory for the given path.
+    Provide the top level directory for the given path.
 
-    The toplevel directory will be the one containing ``controls.json`` file.
-    This function returns ``None`` if toplevel path could not be calculated.
+    The top level directory contains the ``controls.json`` file.
+    This function returns ``None`` if a top level path can not be found.
 
-    :param path: absolute or relative path to file or dir.
+    :param path: absolute or relative path to a file or directory.
+
+    :returns: the absolute path to the top level directory.
     """
-    if path == '/' or path is None:
-        return None
-    if os.path.exists(os.path.join(path, 'controls.json')):
-        return path
-    return get_toplevel_dirpath(os.path.dirname(path))
+    if path is None:
+        return
+    paths = list(Path(path).resolve().parents)
+    if Path(path).resolve().is_dir():
+        paths = [Path(path).resolve()] + paths
+    for path in paths[:-1]:
+        if Path(path, 'controls.json').is_file():
+            return str(path)
 
 
-def load_evidences_modules(toplevel):
+def load_evidences_modules(path):
     """
-    Load the all evidences modules found at toplevel directory.
+    Load all evidences modules found within the ``path`` directory structure.
 
     This function prevents double loading.
 
-    :param toplevel: path to the toplevel directory.
+    :param path: absolute path to a top level directory.
     """
-    for root, dirs, _ in os.walk(toplevel):
-        for d in dirs:
-            try:
-                mod_data = imp.find_module(
-                    'evidences', [os.path.join(root, d)]
-                )
-            except ImportError:
-                continue
-            module_name = f'{d}.evidences'
-            if module_name in sys.modules:
-                continue
-            imp.load_module(module_name, *mod_data)
+    subdirs = [p.parent for p in Path(path).rglob('evidences') if p.is_dir()]
+    for subdir in subdirs:
+        try:
+            mod_data = imp.find_module('evidences', [str(subdir)])
+        except ImportError:
+            continue
+        module_name = f'{subdir.name}.evidences'
+        if module_name in sys.modules:
+            continue
+        imp.load_module(module_name, *mod_data)
 
 
 def substitute_config(path_tmpl):
     """
-    Substitue the config values on the given path template.
+    Substitute the config values on the given path template.
 
     :param path_tmpl: a string template of a path
     """


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Use the `pathlib` library for file path and operating system file interaction throughout the framework
- Fix the bug where the table of contents adds a new line between the locker README main section and the TOC every time checks are run.  Bug fix includes the removal of added blank lines since the bug was introduced.

## Why

1.  Because all the cool kids are using pathlib
2.  Bugs are bad 

## How

- Replace all instances of os.path functionality with pathlib.Path
- Add a regex to the TOC generator to limit the number of blank lines to a max of 2.

## Test

- Locker downloads correctly
- Locker pushes correctly
- Fetchers run
- Checks run
- Notifiers work
- Reports generate
- Metadata is updated as expected
- TOC works

## Context

- Closes #89 
- Fixes #117 
