### PR TITLE
Replace deprecated libs, add PagerDuty doc content, add bandit to GH actions workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -1,4 +1,4 @@
-name: format | lint | test
+name: format | lint | security | test
 on: [push, pull_request]
 jobs:
   lint_unit_tests_coverage:
@@ -21,6 +21,9 @@ jobs:
     - name: Run linter
       run: |
         make code-lint
+    - name: Run security check
+      run: |
+        make code-security
     - name: Run unit tests with coverage
       run: |
         git config --global user.email "you@example.com"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,10 @@ repos:
         ]
         files: "^(compliance|test)"
         stages: [commit]
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.7.0
+    hooks:
+    -   id: bandit
+        args: [--recursive]
+        files: "^(compliance|test)"
+        stages: [commit]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# [1.19.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.19.0)
+
+- [ADDED] Pre-commit hook for running `bandit` as part of CI/CD was added.
+- [CHANGED] Replaced the deprecated `imp` library with `importlib`.
+- [CHANGED] Replaced the deprecated `ibm_security_advisor_findings_api_sdk` library with `ibm_cloud_security_advisor`.
+- [FIXED] Added clarifying PagerDuty notifier documentation content.
+- [FIXED] Addressed `bandit` (minor) security issue findings.
+
 # [1.18.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.18.0)
 
 - [CHANGED] Now using `pathlib` exclusively for operating system filepath and file functionality.

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ code-format:
 code-lint:
 	pre-commit run flake8 --all-files
 
+code-security:
+	pre-commit run bandit --all-files
+
 test::
 	pytest --cov compliance test -v
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![OS Compatibility][platform-badge]](#prerequisites)
 [![Python Compatibility][python-badge]][python]
 [![pre-commit][pre-commit-badge]][pre-commit]
-[![Code validation](https://github.com/ComplianceAsCode/auditree-framework/workflows/format%20%7C%20lint%20%7C%20test/badge.svg)][lint-test]
+[![Code validation](https://github.com/ComplianceAsCode/auditree-framework/workflows/format%20%7C%20lint%20%7C%20security%20%7C%20test/badge.svg)][lint-test]
 [![Upload Python Package](https://github.com/ComplianceAsCode/auditree-framework/workflows/PyPI%20upload/badge.svg)][pypi-upload]
 
 # auditree-framework

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.18.0'
+__version__ = '1.19.0'

--- a/compliance/notify.py
+++ b/compliance/notify.py
@@ -28,9 +28,10 @@ from compliance.utils.services import pagerduty
 from compliance.utils.services.github import Github
 from compliance.utils.test import parse_test_id
 
+from ibm_cloud_sdk_core.api_exception import ApiException
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
 
-from ibm_security_advisor_findings_api_sdk import ApiException, FindingsApiV1
+from ibm_cloud_security_advisor import FindingsApiV1
 
 import requests
 

--- a/compliance/utils/services/github.py
+++ b/compliance/utils/services/github.py
@@ -15,7 +15,7 @@
 """Compliance Github service helper."""
 
 import json
-import random
+import secrets
 from collections import OrderedDict
 from urllib.parse import parse_qs, urlparse
 
@@ -332,9 +332,9 @@ class Github(object):
     def rand_color(self):
         """Generate a random color for labels."""
         return (
-            f'{random.randint(0, 255):02X}'
-            f'{random.randint(0, 255):02X}'
-            f'{random.randint(0, 255):02X}'
+            f'{secrets.randbelow(255):02X}'
+            f'{secrets.randbelow(255):02X}'
+            f'{secrets.randbelow(255):02X}'
         )
 
     def create_label(self, repo, name, org=False):

--- a/doc-source/notifiers.rst
+++ b/doc-source/notifiers.rst
@@ -124,7 +124,7 @@ channel monitoring rotation management::
 
 
 This notifier also needs to know the credentials for sending message
-to your Slack organisation. Include the following in your credentials
+to your Slack organization. Include the following in your credentials
 file::
 
   [slack]
@@ -161,7 +161,7 @@ option when executing your compliance checks.
 
 Note that you have two options to configure the PagerDuty notifier:
 
-* Provide a list of checks by class path within an accreditation. This allows you 
+* Provide a list of checks by class path within an accreditation. This allows you
 to define which checks within the accreditation will trigger PageDuty notifications::
 
   {
@@ -181,13 +181,22 @@ accreditations::
 
   {
     "pagerduty": {
-      "my.accred1": "SERVICE_ID" 
+      "my.accred1": "SERVICE_ID"
     }
   }
 
 Note that the ``service_id`` field is the service id from PagerDuty, e.g. ``PABC123``.
 The PagerDuty notifier loads the active incidents to determine if
 it needs to create a new incident or update an existing one by using the ``service_id``.
+To get your service ID, go to your service in the PagerDuty dashboard and the
+service ID will be the last path element (7 characters) of the URL.  For example
+for ``https://my-service/PABC123``, the service ID is ``PABC123``.
+
+This notifier also needs to know the credentials for sending message to PagerDuty.
+Include the following in your credentials file::
+
+  [pagerduty]
+  events_integration_key=XXX
 
 GitHub Issue
 ------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     inflection>=0.3.1
     GitPython>=2.1.3
     jinja2>=2.10
-    ibm-cloud-security-advisor-findingsapi-sdk>=2.0.5
+    ibm_cloud_security_advisor>=2.0.0
     deprecated>=1.2.9
     ilcli>=0.3.1
 
@@ -45,7 +45,6 @@ console_scripts =
 dev =
     pytest>=5.4.3
     pytest-cov>=2.10.0
-    bandit>=1.5.0
     pre-commit>=2.4.0
     Sphinx>=1.7.2
     setuptools

--- a/test/t_compliance/t_notify/test_findings_notifier.py
+++ b/test/t_compliance/t_notify/test_findings_notifier.py
@@ -23,9 +23,8 @@ from compliance.config import ComplianceConfig
 from compliance.controls import ControlDescriptor
 from compliance.notify import FindingsNotifier
 
+from ibm_cloud_sdk_core.api_exception import ApiException
 from ibm_cloud_sdk_core.authenticators import IAMAuthenticator
-
-from ibm_security_advisor_findings_api_sdk import ApiException
 
 from requests.models import Response
 

--- a/test/t_compliance/t_report/test_report.py
+++ b/test/t_compliance/t_report/test_report.py
@@ -38,7 +38,7 @@ class ReportTest(unittest.TestCase):
     ):
         """Test report generation failure affects on general execution."""
         config_mock = create_autospec(ComplianceConfig)
-        config_mock.get_template_dir.return_value = '/tmp/templates'
+        config_mock.get_template_dir.return_value = '/rpt/templates'
         get_cfg_mock.return_value = config_mock
 
         report = ReportEvidence('test', 'test', 12345)
@@ -46,7 +46,7 @@ class ReportTest(unittest.TestCase):
         evidence_path_mock.return_value = report
 
         locker = create_autospec(Locker())
-        locker.local_path = '/tmp/fake_locker'
+        locker.local_path = '/my/fake/locker'
         locker.get_reports_metadata = MagicMock(return_value={'foo': 'bar'})
 
         test_obj = build_test_mock()


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Replace imp with importlib
- Replace ibm_security_advisor_findings_api_sdk with ibm_cloud_security_advisor
- Add PagerDuty notifier clarifying doc content
- Add bandit to the pre-commit workflow

## Why

- We should be using the latest supported Python libraries
- People using the PagerDuty notifier need more details about the service ID
- Bandit checks the codebase for possible security issues and flaws

## How

- Replaced imp with importlib library in `compliance.utils.path`.
- Replace ibm_security_advisor_findings_api_sdk with ibm_cloud_security_advisor in `compliance.notify`.
- Add PagerDuty notifier clarifying doc content in `notifiers.rst`.
- Add bandit to the pre-commit workflow.

## Test

- library replacement tests yielded no change in current functionality.
- `bandit` added to workflow and ran successfully

## Context

- Closes #100 
- Closes #58 
- Fixes #111 
