### PR TITLE
Fix evidence cache loading bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.19.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.19.1)
+
+- [FIXED] Evidence cache loading bug resolved.
+
 # [1.19.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.19.0)
 
 - [ADDED] Pre-commit hook for running `bandit` as part of CI/CD was added.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.19.0'
+__version__ = '1.19.1'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix evidence cache loading bug

## Why

To prevent double loading which will in turn cause errors to be raised

## How

Replace hash naming of evidences modules with proper Python dot notation naming

## Test

- Original (working) functionality preserved
- Fix resolves the double loading issue

## Context

Fixes #120 
