### PR TITLE
Repository pull request metadata retrieval added to Github service utility

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.21.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.21.0)
+
+- [ADDED] Repository pull request metadata retrieval added to Github service utility.
+
 # [1.20.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.20.0)
 
 - [ADDED] Returned support for `DerivedEvidence`.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.20.0'
+__version__ = '1.21.0'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Create a helper function to retrieve [github pulls API](https://docs.github.com/en/rest/reference/pulls#list-pull-requests).

## Why

The information github pull requests can be useful for configuration controls of many compliance.

## How


The function calls github pulls API and then select only the pull requests that match the given date/time.

## Test

- Test the function locally with a modified auditree fetcher
- Follow this guidance https://complianceascode.github.io/auditree-framework/coding-standards.html

## Context

_Provide a bulleted list of GitHub issues, or any other references (mailing list discussion, etc...) that reviewers can reference
for additional information regarding scope of the pull request._
