### PR TITLE
Fix PagerDuty Notifier

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.21.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.21.1)
+
+- [FIXED] Addressed PagerDuty notifier hanging and not firing pages.
+
 # [1.21.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.21.0)
 
 - [ADDED] Repository pull request metadata retrieval added to Github service utility.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.21.0'
+__version__ = '1.21.1'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

- Stop using undocumented api for getting alerts
- Migrate to /incidents and /incidents/{id}/alerts apis

## Why

The `_get_alerts` method is currently using an undocumented api for getting alerts for a service. This API at current just hangs when called and does not time out. This means that auditree will fail to page if needed and travis will fail to fully complete.

## How

Replaces the `/alerts` api call with a call to `/incidents` to get all incidents for a service and then calls to `/incidents/{id}/alerts` to get the alerts for said incidents. Only alerts that have a `source_origin` of the passed accreditation will be selected.

## Test

I have locally ran our compliance checks both before and after the change. Before the notifier would just hang and after it would page. 

It was also tested that if there is a current alert it would not make a new one. And if we resolved the incident then a new one would get created.

## Context

Fixes #127 
