### PR TITLE
Implement "agent" mode.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# [1.22.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.22.0)
+
+- [ADDED] Agent mode for storing cryptographically signed evidence.
+- [ADDED] Configurable branch name for evidence repository.
+- [ADDED] Configurable force push to remote for evidence repository.
+- [ADDED] Fetcher helper for running local commands.
+- [FIXED] Attempt to import missing fetchers from the include JSON configuration.
+
 # [1.21.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.21.1)
 
 - [FIXED] Addressed PagerDuty notifier hanging and not firing pages.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 graft compliance/templates
+include compliance/utils/fetch_local_commands

--- a/compliance/agent.py
+++ b/compliance/agent.py
@@ -1,0 +1,178 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2022 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compliance check automation module."""
+
+import base64
+import hashlib
+from pathlib import PurePath
+
+from compliance.config import get_config
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+
+
+class ComplianceAgent:
+    """Compliance agent class."""
+
+    AGENTS_DIR = 'agents'
+    PUBLIC_KEYS_EVIDENCE_PATH = 'raw/auditree/agent_public_keys.json'
+
+    def __init__(self, name=None, use_agent_dir=True):
+        """Construct and initialize the agent object."""
+        self._name = name
+        self._private_key = self._public_key = None
+        self._use_agent_dir = use_agent_dir
+
+    @property
+    def name(self):
+        """Get agent name."""
+        return self._name
+
+    @property
+    def private_key(self):
+        """Get agent private key."""
+        return self._private_key
+
+    @private_key.setter
+    def private_key(self, data_bytes):
+        """
+        Set agent private key.
+
+        :param data_bytes: The PEM encoded key data as `bytes`.
+        """
+        self._private_key = serialization.load_pem_private_key(
+            data_bytes, None, default_backend()
+        )
+
+    @property
+    def public_key(self):
+        """Get agent public key."""
+        return self._public_key
+
+    @public_key.setter
+    def public_key(self, data_bytes):
+        """
+        Set agent public key.
+
+        :param data_bytes: The PEM encoded key data as `bytes`.
+        """
+        if self.name:
+            self._public_key = serialization.load_pem_public_key(data_bytes)
+
+    def get_path(self, path):
+        """
+        Get the full evidence path.
+
+        :param path: The relative evidence path as a string.
+
+        :returns: The full evidence path as a string.
+        """
+        if self.name and self._use_agent_dir:
+            if PurePath(path).parts[0] != self.AGENTS_DIR:
+                return str(PurePath(self.AGENTS_DIR, self.name, path))
+        return path
+
+    def signable(self):
+        """Determine if the agent can sign evidence."""
+        return self.name and self.private_key
+
+    def verifiable(self):
+        """Determine if the agent can verify evidence."""
+        return self.name and self.public_key
+
+    def load_public_key_from_locker(self, locker):
+        """
+        Load agent public key from locker.
+
+        :param locker: A locker of type :class:`compliance.locker.Locker`.
+        """
+        if not self.name:
+            return
+        try:
+            public_keys = locker.get_evidence(self.PUBLIC_KEYS_EVIDENCE_PATH)
+            public_key_str = public_keys.content_as_json[self.name]
+            self.public_key = public_key_str.encode()
+        except Exception:
+            self._public_key = None  # Missing public key evidence.
+
+    def hash_and_sign(self, data_bytes):
+        """
+        Hash and sign evidence using the agent private key.
+
+        :param data_bytes: The data to sign as `bytes`.
+
+        :returns: A `tuple` containing the hexadecimal digest string and the
+          base64 encoded signature string. Returns tuple `(None, None)` if the
+          agent is not configured to sign evidence.
+        """
+        if not self.signable():
+            return None, None
+        hashed = hashlib.sha256(data_bytes)
+        signature = self.private_key.sign(
+            hashed.digest(),
+            padding.PSS(
+                mgf=padding.MGF1(hashes.SHA256()),
+                salt_length=padding.PSS.MAX_LENGTH
+            ),
+            Prehashed(hashes.SHA256())
+        )
+        return hashed.hexdigest(), base64.b64encode(signature).decode()
+
+    def verify(self, data_bytes, signature_b64):
+        """
+        Verify evidence using the agent public key.
+
+        :param data_bytes: The data to verify as `bytes`.
+        :param signature_b64: The base64 encoded signature string.
+
+        :returns: `True` if data can be verified, else `False`.
+        """
+        if not self.verifiable():
+            return False
+        try:
+            self.public_key.verify(
+                base64.b64decode(signature_b64),
+                data_bytes,
+                padding.PSS(
+                    mgf=padding.MGF1(hashes.SHA256()),
+                    salt_length=padding.PSS.MAX_LENGTH
+                ),
+                hashes.SHA256()
+            )
+            return True
+        except InvalidSignature:
+            return False
+
+    @classmethod
+    def from_config(cls):
+        """Load agent from configuration."""
+        config = get_config()
+        agent = cls(
+            name=config.get('agent_name'),
+            use_agent_dir=config.get('use_agent_dir', True)
+        )
+        key_path = config.get('agent_private_key')
+        if key_path:
+            with open(key_path, 'rb') as key_file:
+                agent.private_key = key_file.read()
+            agent.public_key = agent.private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PublicFormat.SubjectPublicKeyInfo
+            )
+        return agent

--- a/compliance/agent.py
+++ b/compliance/agent.py
@@ -90,11 +90,11 @@ class ComplianceAgent:
 
     def signable(self):
         """Determine if the agent can sign evidence."""
-        return self.name and self.private_key
+        return all([self.name, self.private_key])
 
     def verifiable(self):
         """Determine if the agent can verify evidence."""
-        return self.name and self.public_key
+        return all([self.name, self.public_key])
 
     def load_public_key_from_locker(self, locker):
         """

--- a/compliance/agent.py
+++ b/compliance/agent.py
@@ -167,12 +167,16 @@ class ComplianceAgent:
             name=config.get('agent_name'),
             use_agent_dir=config.get('use_agent_dir', True)
         )
-        key_path = config.get('agent_private_key')
-        if key_path:
-            with open(key_path, 'rb') as key_file:
+        private_key_path = config.get('agent_private_key')
+        public_key_path = config.get('agent_public_key')
+        if private_key_path:
+            with open(private_key_path, 'rb') as key_file:
                 agent.private_key = key_file.read()
             agent.public_key = agent.private_key.public_key().public_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PublicFormat.SubjectPublicKeyInfo
             )
+        elif public_key_path:
+            with open(public_key_path, 'rb') as key_file:
+                agent.public_key = key_file.read()
         return agent

--- a/compliance/locker.py
+++ b/compliance/locker.py
@@ -541,12 +541,14 @@ class Locker(object):
                 ),
                 sign=False
             )
-        if evidence.is_signed(self) and not evidence.verify_signature(self):
-            raise UnverifiedEvidenceError(
-                f'Evidence {evidence.path} is signed but the signature could '
-                'not be verified.',
-                evidence
-            )
+        ign_sig = get_config().get('locker.ignore_signatures', default=False)
+        if not ign_sig and evidence.is_signed(self):
+            if not evidence.verify_signature(self):
+                raise UnverifiedEvidenceError(
+                    f'Evidence {evidence.path} is signed but the signature '
+                    'could not be verified.',
+                    evidence
+                )
         return evidence
 
     def validate(self, evidence, ignore_ttl=False):
@@ -876,7 +878,8 @@ class Locker(object):
                 },
                 binary_content=metadata.get('binary_content', False),
                 filtered_content=metadata.get('filtered_content', False),
-                agent=agent
+                agent=agent,
+                evidence_dt=evidence_dt
             )
         except TypeError:
             ev_dt_str = (evidence_dt or dt.utcnow()).strftime('%Y-%m-%d')

--- a/compliance/locker.py
+++ b/compliance/locker.py
@@ -118,7 +118,10 @@ class Locker(object):
             self.name = repo_url.rsplit('/', 1)[1]
         elif repo_url is None and name is None:
             self.name = 'example'
-        self.local_path = str(PurePath(tempfile.gettempdir(), self.name))
+        self.local_path = get_config().get(
+            'locker.local_path',
+            str(PurePath(tempfile.gettempdir(), self.name))
+        )
         self._do_push = do_push
         self.ttl_tolerance = ttl_tolerance
         self.gitconfig = gitconfig or {}

--- a/compliance/locker.py
+++ b/compliance/locker.py
@@ -656,7 +656,11 @@ class Locker(object):
             self.logger.info(
                 f'Pushing local locker to remote repo {self.repo_url}...'
             )
-            push_info = remote.push(self.branch, set_upstream=True)[0]
+            push_info = remote.push(
+                self.branch,
+                force=get_config().get('locker.force_push', default=False),
+                set_upstream=True
+            )[0]
             if push_info.flags >= git.remote.PushInfo.ERROR:
                 raise LockerPushError(push_info)
 

--- a/compliance/runners.py
+++ b/compliance/runners.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020 IBM Corp. All rights reserved.
+# Copyright (c) 2021, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -115,7 +115,10 @@ class _BaseRunner(object):
         gitconfig = self.config.get('locker.gitconfig')
         if mode == 'local':
             return Locker(
-                name=dirname, ttl_tolerance=ttl_tolerance, gitconfig=gitconfig
+                name=dirname,
+                ttl_tolerance=ttl_tolerance,
+                gitconfig=gitconfig,
+                branch=self.config.get('locker.branch')
             )
         repo_url = self.config.get('locker.repo_url')
         if repo_url is None:
@@ -126,7 +129,8 @@ class _BaseRunner(object):
             creds=self.config.creds,
             do_push=True if mode == 'full-remote' else False,
             ttl_tolerance=ttl_tolerance,
-            gitconfig=gitconfig
+            gitconfig=gitconfig,
+            branch=self.config.get('locker.branch')
         )
 
 

--- a/compliance/utils/exceptions.py
+++ b/compliance/utils/exceptions.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020 IBM Corp. All rights reserved.
+# Copyright (c) 2021, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -41,6 +41,12 @@ class DependencyUnavailableError(ValueError):
 
 class DependencyFetcherNotFoundError(ValueError):
     """Dependency fetcher not found exception class."""
+
+    pass
+
+
+class UnverifiedEvidenceError(Exception):
+    """Unverified evidence exception class."""
 
     pass
 

--- a/compliance/utils/fetch_local_commands
+++ b/compliance/utils/fetch_local_commands
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright (c) 2022 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+usage() {
+  echo "Usage: $0 [-h] [-u <user>]"
+  echo "       -h    Print usage."
+  echo "       -s    Show exit status."
+  echo "       -t    Show timestamp."
+  return 1
+} 1>&2
+
+show_exit_status=0
+show_timestamp=0
+while getopts :hst option
+do
+  case $option in
+    h)
+      usage
+      exit 0
+      ;;
+    s)
+      show_exit_status=1
+      ;;
+    t)
+      show_timestamp=1
+      ;;
+    *)
+      echo "Error: Illegal option -$OPTARG specified." 1>&2
+      exit "$(usage)"
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+ps1() {
+  if [[ "$show_timestamp" -eq 1 ]]; then
+    printf '[%s] %s@%s:%s$' "$(date -u +%FT%TZ)" "$(whoami)" "$(hostname -f)" "${PWD/#$HOME/~}"
+  else
+    printf '%s@%s:%s$' "$(whoami)" "$(hostname -f)" "${PWD/#$HOME/~}"
+  fi
+}
+
+run() {
+  printf '%s ' "$(ps1)" "$@"
+  printf '\n'
+  eval "$@"; rc="$?"
+  if [[ "$show_exit_status" -eq 1 ]]; then
+    printf '%s %s\n%s\n' "$(ps1)" 'echo $?' "$rc"
+  fi
+}
+
+while IFS=$'\n' read -r cmd; do
+  run "$cmd" 2>&1
+done

--- a/doc-source/index.rst
+++ b/doc-source/index.rst
@@ -49,6 +49,7 @@ Guides
    coding-standards
    running-on-travis
    running-on-tekton
+   verifying-signed-evidence
 
 Source code
 -----------

--- a/doc-source/quick-start.rst
+++ b/doc-source/quick-start.rst
@@ -69,7 +69,8 @@ Agents
 
 All fetchers can be executed in "agent" mode. Agents will cryptographically sign
 any evidence they fetch. The agent name, evidence digest and signature can be
-found in the ``index.json`` metadata file.
+found in the ``index.json`` metadata file. See :ref:`verifying-signed-evidence`
+for instructions on how to manually verify signatures.
 
 To configure an agent, add the following to your main configuration::
 

--- a/doc-source/quick-start.rst
+++ b/doc-source/quick-start.rst
@@ -64,6 +64,43 @@ As an example, the format for ``controls.json`` is as follows::
     "chk_pkg.chk_cat_bar.checks.chk_module_bar.BarCheckClass": ["accred.one", "accred.two"]
   }
 
+Agents
+~~~~~~
+
+All fetchers can be executed in "agent" mode. Agents will cryptographically sign
+any evidence they fetch. The agent name, evidence digest and signature can be
+found in the ``index.json`` metadata file.
+
+To configure an agent, add the following to your main configuration::
+
+  {
+    "agent_name": "my-agent-name",
+    "agent_private_key": "/path/to/key.pem",
+    ...
+  }
+
+Each agent must have a unique name. By default, any evidence created by an agent
+will be stored under the corresponding agent directory (e.g.
+``agents/my-agent-name/raw/system/uptime.txt``). You can set
+``"use_agent_dir": false`` to suppress this behavior.
+
+Signed evidence can be used in checks. It is automatically verified when it's
+loaded from the locker. The public key used to verify the evidence must be made
+available in the locker under ``raw/auditree/agent_public_keys.json``. This is a
+special evidence and must take the following form::
+
+  {
+    "my-agent-name": "-----BEGIN PUBLIC KEY-----\n...",
+    "my-other-agent-name": "-----BEGIN PUBLIC KEY-----\n...",
+    ...
+  }
+
+We recommend you implement an additional fetcher to pull this public keys
+evidence into the locker and ensure it's kept up-to-date. You can sign this
+evidence too using an agent configured with ``"use_agent_dir": false``. However,
+it means only that agent can then be used to execute checks against any signed
+evidence.
+
 Remote Evidence Locker
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc-source/verifying-signed-evidence.rst
+++ b/doc-source/verifying-signed-evidence.rst
@@ -1,0 +1,63 @@
+.. -*- mode:rst; coding:utf-8 -*-
+
+.. _verifying-signed-evidence:
+
+Verifying Signed Evidence
+=========================
+
+Follow the instructions to manually verify the sample evidence below::
+
+  -----BEGIN AGENT-----
+  auditree.local
+  -----END AGENT-----
+  -----BEGIN CONTENT-----
+  This is my evidence.
+  -----END CONTENT-----
+  -----BEGIN DIGEST-----
+  81ddd37cb8aba90077a717b7d6c067815add58e658bb2be0dea4d4d9301c762d
+  -----END DIGEST-----
+  -----BEGIN SIGNATURE-----
+  xRIu2dey1WSCSRpBWHlar5XUv13vZtm1n/KEDckA85UoQjEqEo7xlmnpzBtkNcieME6frhBMmBOYPW4uFYS1EUtLxkixYkYjt3wKlHl8CkvKDFoqAMqG8AC/cCdqwP7D7SlO5RH1pJ1kp2yX2XB2MTMHkd/9tguNZBpaCnscYCmpBvng6okB7HbToOlVUfKY1tWDDIm3JefFMEoJqXgIEZMmVnF+nLniF/PvPTL+q38e6Wd1xeJpZYiLk12imarzkf9MweA5D22xkv51pI2ils3jovxymzio26cSkL7iHBsbiNOWWXoETo0aYm2g9CzhxnRGku9OEkW97JGNASkjSw==
+  -----END SIGNATURE-----
+
+1. Fetch the public key for the ``auditree.local`` agent. This can be collected
+   directly from the agent or the public keys evidence (available in the locker
+   under ``raw/auditree/agent_public_keys.json``)::
+
+     $ cat > key.pub
+     -----BEGIN PUBLIC KEY-----
+     MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxYosRYnahnSuH3SmNupn
+     zQhxJsDEhqChKjrcyN19L8+vcjUUiMSaKRoAHuUKp5Pfwkoylryd4AyXIU9UnXZg
+     dIOl2+r5xzXqfdLwi+PAU/eEWPLAQfCpIodqKqBLCyzpMoJHv9GDqg8XJkY/2i8j
+     7oiqLR7vibIgRAJXqF95KdNvbW7Gvu8JHigN4aoGdbQSPp/jJ30wBvy7hHOSrMWF
+     iQUt7H25YbvOZGWQeC8HZ2EXruzG+FV2rkW52FaTn31lX1EEc2Yz8AI7/yF/8C5j
+     SSL/pmzxBzh/P4zGDNlm2habpwAIQpHnJJ8XeXYS//RXuOYNObeRwfhm82TB9+nS
+     lQIDAQAB
+     -----END PUBLIC KEY-----
+
+2. Save the evidence content to your local filesystem and verify the digest::
+
+     $ cat > evidence.txt
+     This is my evidence.
+
+     $ openssl dgst -sha256 evidence.txt
+     SHA256(evidence.txt)= 81ddd37cb8aba90077a717b7d6c067815add58e658bb2be0dea4d4d9301c762d
+
+   *Be sure not to add any additional whitespace when saving evidence locally.*
+
+3. Save the signature to your local filesystem::
+
+     $ cat > signature.txt
+     xRIu2dey1WSCSRpBWHlar5XUv13vZtm1n/KEDckA85UoQjEqEo7xlmnpzBtkNcieME6frhBMmBOYPW4uFYS1EUtLxkixYkYjt3wKlHl8CkvKDFoqAMqG8AC/cCdqwP7D7SlO5RH1pJ1kp2yX2XB2MTMHkd/9tguNZBpaCnscYCmpBvng6okB7HbToOlVUfKY1tWDDIm3JefFMEoJqXgIEZMmVnF+nLniF/PvPTL+q38e6Wd1xeJpZYiLk12imarzkf9MweA5D22xkv51pI2ils3jovxymzio26cSkL7iHBsbiNOWWXoETo0aYm2g9CzhxnRGku9OEkW97JGNASkjSw==
+
+4. Convert the Base64 signature to binary::
+
+     $ openssl base64 -d -in signature.txt -out evidence.sig
+
+5. Verify the signature::
+
+     $ openssl dgst -sha256 -verify key.pub -signature evidence.sig -sigopt rsa_padding_mode:pss evidence.txt
+     Verified OK
+
+   If the verification is successful, the OpenSSL command will print the
+   ``Verified OK`` message, otherwise it will print ``Verification Failure``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     jinja2>=2.10
     ibm_cloud_security_advisor>=2.0.0
     ilcli>=0.3.1
+    cryptography>=35.0.0
 
 [options.packages.find]
 exclude =

--- a/test/t_compliance/t_agent/__init__.py
+++ b/test/t_compliance/t_agent/__init__.py
@@ -1,5 +1,5 @@
 # -*- mode:python; coding:utf-8 -*-
-# Copyright (c) 2020, 2022 IBM Corp. All rights reserved.
+# Copyright (c) 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,6 +12,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Compliance automation package."""
-
-__version__ = '1.22.0'
+"""Compliance automation agent tests package."""

--- a/test/t_compliance/t_agent/test_agent.py
+++ b/test/t_compliance/t_agent/test_agent.py
@@ -1,0 +1,279 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2022 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compliance automation agent tests module."""
+
+import unittest
+try:
+    from mock import Mock, create_autospec, mock_open, patch
+except ImportError:
+    from unittest.mock import Mock, create_autospec, mock_open, patch
+
+from compliance.agent import ComplianceAgent
+from compliance.evidence import RawEvidence
+from compliance.locker import Locker
+from compliance.utils.exceptions import EvidenceNotFoundError
+
+
+class TestSigningEvidence(unittest.TestCase):
+    """Test evidence signing logic."""
+
+    def setUp(self):
+        """Prepare the test fixture."""
+        self.name = 'auditree.local'
+        self.evidence = b'This is my evidence.'
+        self.expected_digest = (
+            '81ddd37cb8aba90077a717b7d6c067815add58e658bb2'
+            'be0dea4d4d9301c762d'
+        )
+        self.priv_key = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAxYosRYnahnSuH3SmNupnzQhxJsDEhqChKjrcyN19L8+vcjUU
+iMSaKRoAHuUKp5Pfwkoylryd4AyXIU9UnXZgdIOl2+r5xzXqfdLwi+PAU/eEWPLA
+QfCpIodqKqBLCyzpMoJHv9GDqg8XJkY/2i8j7oiqLR7vibIgRAJXqF95KdNvbW7G
+vu8JHigN4aoGdbQSPp/jJ30wBvy7hHOSrMWFiQUt7H25YbvOZGWQeC8HZ2EXruzG
++FV2rkW52FaTn31lX1EEc2Yz8AI7/yF/8C5jSSL/pmzxBzh/P4zGDNlm2habpwAI
+QpHnJJ8XeXYS//RXuOYNObeRwfhm82TB9+nSlQIDAQABAoIBAEkaSintyxXpBisT
+4xL9ii5hSmZ5/gCIXzwejmgzN0nDRP0x0YiPoTFGsva78kZzveHLzY7k/FPWtPMZ
+xYmELkvQEEgjXA4x0LaBoo1SWnF4btzv8OA2LJFfpZVivoLDOwV7GwxMf7omXX3H
+j4ex3E1A/CE4ipLdfX1NlJz1wAQO2Q/kiw6tZV8axYwYjT8+z1MANIsx6Mtjzfku
+YtrfMcPuvXjXHeoOKdD3Fn1PdAaj6RXWCm8NkED/k6JOaAeTTaO4o6t8VvhtHYG8
+4jCzbWdc07OAUuwyynbuVypAWp+PDz1/0ID+WKW4FHN7HT0iEWtG34pc3ls2Hlu/
+/QZEDiECgYEA8g/tEwa97H1m8j3jzMoi6NOfceENYUGxLiSu9dtY8QAlz+G12LJi
+39x1Fcpi4sPTB2ITdy3vp1EAVVePCjVLxPv3vV474bIFQSqW/IoRCSYQCOOt2IkS
+RL9NhZoMyWbpBx1OlOKDPzoJLRUho1EF/JRwJ1YebfYssq4ce1fjAxkCgYEA0On4
+sYryVp/jJGmlC8m713/ioNgV+zzGn9M4GUjY7LPZSH4Pgll9LisK13+z32pl7KWQ
+zcdg/lcpSZaIn4HohzPg0Lv43Up0BjXjrOrqhtoUwfWMoDgV7IqwPFYNLFQjUo+N
+A2/x1+6hlotjrmPr09REo02aCj2ZVp/i3K2MFt0CgYEAtRUK8nfRrs/lKoT4HGR/
+FxPxLJ0CiGY/aNiSdmQANlI49znP8usIIpXmlUWREjkSbmyFSVv4838aM73LyQQz
+yYoBPA352A539dcpmoSi1+g8iJninKF2JC3EjZS/yg8NdoALIEAPlUYSRUKQpn9f
+biORfyvimbpWl9i+f9swfUkCgYAkVWzhQ+8dzbTtcko4IJ/AvQcnPi2kgk9xIIUT
+MK45jJXvm60K2JGC5A2AqT8ZTiHn5GuovlJKKdKOb9XXF/re+NDSvL5tjjNbmSe9
+vSWIyojtqs0IWHjHqN85vyWPXhq+kyTNQjzndyM3UYrGm646KyK83BQ8T7ZJcIk+
+JBjHKQKBgQDwxwhFKfgq9n420Vz5QIgZCT3pcmEvqQzAsxLfeOz7RYNHqECMl6FY
+p6u8/fRZssZdelNwkUQMMw1gTdhV91Xd/3lbfoWQ72KnaITItUqYgP3Th9AQOFyO
+YLmlUVKZU7mt43D8aj8l4l11jWDBkvOba/wJ7CjTQ15ik4ntl9TRzg==
+-----END RSA PRIVATE KEY-----
+""".encode()
+
+        self.pub_key = """
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxYosRYnahnSuH3SmNupn
+zQhxJsDEhqChKjrcyN19L8+vcjUUiMSaKRoAHuUKp5Pfwkoylryd4AyXIU9UnXZg
+dIOl2+r5xzXqfdLwi+PAU/eEWPLAQfCpIodqKqBLCyzpMoJHv9GDqg8XJkY/2i8j
+7oiqLR7vibIgRAJXqF95KdNvbW7Gvu8JHigN4aoGdbQSPp/jJ30wBvy7hHOSrMWF
+iQUt7H25YbvOZGWQeC8HZ2EXruzG+FV2rkW52FaTn31lX1EEc2Yz8AI7/yF/8C5j
+SSL/pmzxBzh/P4zGDNlm2habpwAIQpHnJJ8XeXYS//RXuOYNObeRwfhm82TB9+nS
+lQIDAQAB
+-----END PUBLIC KEY-----
+""".encode()
+
+        # Mock empty locker.
+        self.mock_empty_locker = create_autospec(Locker)
+        self.mock_empty_locker.get_evidence.side_effect = Mock(
+            side_effect=EvidenceNotFoundError('Evidence not found in locker.')
+        )
+
+        # Mock locker containing public key evidence.
+        mock_locker_evidence = create_autospec(RawEvidence)
+        mock_locker_evidence.content_as_json = {
+            self.name: self.pub_key.decode()
+        }
+        self.mock_locker = create_autospec(Locker)
+        self.mock_locker.get_evidence.return_value = mock_locker_evidence
+
+    @patch('compliance.agent.get_config')
+    def test_empty_agent_from_config(self, get_config_mock):
+        """Test load empty agent from configuration."""
+        get_config_mock.return_value = {}
+
+        agent = ComplianceAgent.from_config()
+
+        self.assertIsNone(agent.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertFalse(agent.verifiable())
+
+    @patch('compliance.agent.get_config')
+    def test_agent_from_config_no_key(self, get_config_mock):
+        """Test load agent with no key from configuration."""
+        get_config_mock.return_value = {'agent_name': self.name}
+
+        agent = ComplianceAgent.from_config()
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertFalse(agent.verifiable())
+
+    @patch('compliance.agent.get_config')
+    def test_agent_from_config(self, get_config_mock):
+        """Test load agent from configuration."""
+        get_config_mock.return_value = {
+            'agent_name': self.name, 'agent_private_key': '/path/to/key'
+        }
+
+        with patch('builtins.open', mock_open(read_data=self.priv_key)):
+            agent = ComplianceAgent.from_config()
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNotNone(agent.private_key)
+        self.assertIsNotNone(agent.public_key)
+        self.assertTrue(agent.signable())
+        self.assertTrue(agent.verifiable())
+
+    def test_empty_agent(self):
+        """Test init empty agent."""
+        agent = ComplianceAgent()
+
+        self.assertIsNone(agent.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertFalse(agent.verifiable())
+
+    def test_agent_no_keys(self):
+        """Test init agent with no keys."""
+        agent = ComplianceAgent(name=self.name)
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertFalse(agent.verifiable())
+
+    def test_agent_private_key(self):
+        """Test init agent with private key."""
+        agent = ComplianceAgent(name=self.name)
+        agent.private_key = self.priv_key
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNotNone(agent.private_key)
+        self.assertIsNone(agent.public_key)
+        self.assertTrue(agent.signable())
+        self.assertFalse(agent.verifiable())
+
+    def test_agent_public_key(self):
+        """Test init agent with public key."""
+        agent = ComplianceAgent(name=self.name)
+        agent.public_key = self.pub_key
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNotNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertTrue(agent.verifiable())
+
+    def test_agent_both_keys(self):
+        """Test init agent."""
+        agent = ComplianceAgent(name=self.name)
+        agent.private_key = self.priv_key
+        agent.public_key = self.pub_key
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNotNone(agent.private_key)
+        self.assertIsNotNone(agent.public_key)
+        self.assertTrue(agent.signable())
+        self.assertTrue(agent.verifiable())
+
+    def test_agent_load_public_key(self):
+        """Test load public key from locker."""
+        agent = ComplianceAgent(name=self.name)
+        agent.load_public_key_from_locker(self.mock_locker)
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNotNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertTrue(agent.verifiable())
+
+    def test_empty_agent_load_public_key(self):
+        """Test load public key from locker for empty agent."""
+        agent = ComplianceAgent()
+        agent.load_public_key_from_locker(self.mock_empty_locker)
+
+        self.assertIsNone(agent.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertFalse(agent.verifiable())
+
+    def test_agent_load_public_key_missing(self):
+        """Test load missing public key from locker."""
+        agent = ComplianceAgent(name=self.name)
+        agent.load_public_key_from_locker(self.mock_empty_locker)
+
+        self.assertEqual(agent.name, self.name)
+        self.assertIsNone(agent.private_key)
+        self.assertIsNone(agent.public_key)
+        self.assertFalse(agent.signable())
+        self.assertFalse(agent.verifiable())
+
+    def test_agent_sign_failure(self):
+        """Test agent sign for missing key."""
+        agent = ComplianceAgent(name=self.name)
+
+        self.assertEqual(agent.name, self.name)
+        self.assertFalse(agent.signable())
+        self.assertEqual((None, None), agent.hash_and_sign(self.evidence))
+
+    def test_agent_sign_success(self):
+        """Test agent sign success."""
+        agent = ComplianceAgent(name=self.name)
+        agent.private_key = self.priv_key
+        digest, signature = agent.hash_and_sign(self.evidence)
+
+        self.assertEqual(agent.name, self.name)
+        self.assertTrue(agent.signable())
+        self.assertEqual(self.expected_digest, digest)
+        self.assertIsNotNone(signature)
+
+    def test_agent_verify_failure_missing_key(self):
+        """Test agent verify failure for missing key."""
+        agent = ComplianceAgent(name=self.name)
+        agent.private_key = self.priv_key
+        digest, signature = agent.hash_and_sign(self.evidence)
+
+        self.assertEqual(agent.name, self.name)
+        self.assertTrue(agent.signable())
+        self.assertFalse(agent.verifiable())
+        self.assertFalse(agent.verify(self.evidence, signature))
+
+    def test_agent_verify_failure_tamper(self):
+        """Test agent verify failure for tampered evidence."""
+        agent = ComplianceAgent(name=self.name)
+        agent.private_key = self.priv_key
+        agent.public_key = self.pub_key
+        _digest, signature = agent.hash_and_sign(self.evidence)
+
+        self.evidence += b'foo'  # Tamper with evidence.
+
+        self.assertEqual(agent.name, self.name)
+        self.assertTrue(agent.signable())
+        self.assertTrue(agent.verifiable())
+        self.assertFalse(agent.verify(self.evidence, signature))
+
+    def test_agent_verify_success(self):
+        """Test agent verify success."""
+        agent = ComplianceAgent(name=self.name)
+        agent.private_key = self.priv_key
+        agent.public_key = self.pub_key
+        _digest, signature = agent.hash_and_sign(self.evidence)
+
+        self.assertEqual(agent.name, self.name)
+        self.assertTrue(agent.signable())
+        self.assertTrue(agent.verifiable())
+        self.assertTrue(agent.verify(self.evidence, signature))

--- a/test/t_compliance/t_evidence/test_signing.py
+++ b/test/t_compliance/t_evidence/test_signing.py
@@ -1,0 +1,204 @@
+# -*- mode:python; coding:utf-8 -*-
+# Copyright (c) 2022 IBM Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Compliance automation evidence signing tests module."""
+
+import unittest
+try:
+    from mock import Mock, create_autospec
+except ImportError:
+    from unittest.mock import Mock, create_autospec
+
+from compliance.agent import ComplianceAgent
+from compliance.evidence import RawEvidence
+from compliance.locker import Locker
+from compliance.utils.exceptions import EvidenceNotFoundError
+
+
+class TestSigningEvidence(unittest.TestCase):
+    """Test evidence signing logic."""
+
+    def setUp(self):
+        """Prepare the test fixture."""
+        self.evidence = 'This is my evidence.'
+        self.expected_digest = (
+            '81ddd37cb8aba90077a717b7d6c067815add58e658bb2'
+            'be0dea4d4d9301c762d'
+        )
+
+        self.agent = ComplianceAgent(name='auditree.local')
+        self.unknown_agent = ComplianceAgent(name='unknown.local')
+        self.agent.private_key = self.unknown_agent.private_key = """
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAxYosRYnahnSuH3SmNupnzQhxJsDEhqChKjrcyN19L8+vcjUU
+iMSaKRoAHuUKp5Pfwkoylryd4AyXIU9UnXZgdIOl2+r5xzXqfdLwi+PAU/eEWPLA
+QfCpIodqKqBLCyzpMoJHv9GDqg8XJkY/2i8j7oiqLR7vibIgRAJXqF95KdNvbW7G
+vu8JHigN4aoGdbQSPp/jJ30wBvy7hHOSrMWFiQUt7H25YbvOZGWQeC8HZ2EXruzG
++FV2rkW52FaTn31lX1EEc2Yz8AI7/yF/8C5jSSL/pmzxBzh/P4zGDNlm2habpwAI
+QpHnJJ8XeXYS//RXuOYNObeRwfhm82TB9+nSlQIDAQABAoIBAEkaSintyxXpBisT
+4xL9ii5hSmZ5/gCIXzwejmgzN0nDRP0x0YiPoTFGsva78kZzveHLzY7k/FPWtPMZ
+xYmELkvQEEgjXA4x0LaBoo1SWnF4btzv8OA2LJFfpZVivoLDOwV7GwxMf7omXX3H
+j4ex3E1A/CE4ipLdfX1NlJz1wAQO2Q/kiw6tZV8axYwYjT8+z1MANIsx6Mtjzfku
+YtrfMcPuvXjXHeoOKdD3Fn1PdAaj6RXWCm8NkED/k6JOaAeTTaO4o6t8VvhtHYG8
+4jCzbWdc07OAUuwyynbuVypAWp+PDz1/0ID+WKW4FHN7HT0iEWtG34pc3ls2Hlu/
+/QZEDiECgYEA8g/tEwa97H1m8j3jzMoi6NOfceENYUGxLiSu9dtY8QAlz+G12LJi
+39x1Fcpi4sPTB2ITdy3vp1EAVVePCjVLxPv3vV474bIFQSqW/IoRCSYQCOOt2IkS
+RL9NhZoMyWbpBx1OlOKDPzoJLRUho1EF/JRwJ1YebfYssq4ce1fjAxkCgYEA0On4
+sYryVp/jJGmlC8m713/ioNgV+zzGn9M4GUjY7LPZSH4Pgll9LisK13+z32pl7KWQ
+zcdg/lcpSZaIn4HohzPg0Lv43Up0BjXjrOrqhtoUwfWMoDgV7IqwPFYNLFQjUo+N
+A2/x1+6hlotjrmPr09REo02aCj2ZVp/i3K2MFt0CgYEAtRUK8nfRrs/lKoT4HGR/
+FxPxLJ0CiGY/aNiSdmQANlI49znP8usIIpXmlUWREjkSbmyFSVv4838aM73LyQQz
+yYoBPA352A539dcpmoSi1+g8iJninKF2JC3EjZS/yg8NdoALIEAPlUYSRUKQpn9f
+biORfyvimbpWl9i+f9swfUkCgYAkVWzhQ+8dzbTtcko4IJ/AvQcnPi2kgk9xIIUT
+MK45jJXvm60K2JGC5A2AqT8ZTiHn5GuovlJKKdKOb9XXF/re+NDSvL5tjjNbmSe9
+vSWIyojtqs0IWHjHqN85vyWPXhq+kyTNQjzndyM3UYrGm646KyK83BQ8T7ZJcIk+
+JBjHKQKBgQDwxwhFKfgq9n420Vz5QIgZCT3pcmEvqQzAsxLfeOz7RYNHqECMl6FY
+p6u8/fRZssZdelNwkUQMMw1gTdhV91Xd/3lbfoWQ72KnaITItUqYgP3Th9AQOFyO
+YLmlUVKZU7mt43D8aj8l4l11jWDBkvOba/wJ7CjTQ15ik4ntl9TRzg==
+-----END RSA PRIVATE KEY-----
+""".encode()
+
+        self.pub_key = """
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAxYosRYnahnSuH3SmNupn
+zQhxJsDEhqChKjrcyN19L8+vcjUUiMSaKRoAHuUKp5Pfwkoylryd4AyXIU9UnXZg
+dIOl2+r5xzXqfdLwi+PAU/eEWPLAQfCpIodqKqBLCyzpMoJHv9GDqg8XJkY/2i8j
+7oiqLR7vibIgRAJXqF95KdNvbW7Gvu8JHigN4aoGdbQSPp/jJ30wBvy7hHOSrMWF
+iQUt7H25YbvOZGWQeC8HZ2EXruzG+FV2rkW52FaTn31lX1EEc2Yz8AI7/yF/8C5j
+SSL/pmzxBzh/P4zGDNlm2habpwAIQpHnJJ8XeXYS//RXuOYNObeRwfhm82TB9+nS
+lQIDAQAB
+-----END PUBLIC KEY-----
+"""
+
+        # Mock empty locker.
+        self.mock_empty_locker = create_autospec(Locker)
+        self.mock_empty_locker.get_evidence.side_effect = Mock(
+            side_effect=EvidenceNotFoundError('Evidence not found in locker.')
+        )
+
+        # Mock locker containing public key evidence.
+        mock_locker_evidence = create_autospec(RawEvidence)
+        mock_locker_evidence.content_as_json = {self.agent.name: self.pub_key}
+        self.mock_locker = create_autospec(Locker)
+        self.mock_locker.get_evidence.return_value = mock_locker_evidence
+        self.mock_locker.get_evidence_metadata.return_value = {
+            'digest': self.expected_digest,
+            'signature': (
+                'jMKH9pWRc8g2ai0sSvXv+XRD6rptlOpU9wJHePuzIby4fmmk/ls'
+                '0WKdxP4fKz1sPtMNsH1mLx7EhM9/vBDGRj85gkGDS2x+FFXkUte'
+                'VNPUAaW9sJx+Fhd8YdRkuyxxKx3lmMQuwopzrnSA+SH0LX22b+d'
+                'DtFxTwzg/r2kFenaqNPWlRHAd07T/RNq2DFA/+mdIY4mE8zz8bS'
+                'B/IiJmKupLdTGxNBuu32wSJq4aGVZ7QXdkk4rzXcgKoS4PfooLS'
+                'pmlive1T1ifbT6khMlTWC46Nx+fv8T+JoN2hB9Mf9PQ0ZCuuZeE'
+                '8RYYyttqa+b/YExraesjIjY8X63wxM9FtNvQ=='
+            )
+        }
+
+    def test_evidence_sign(self):
+        """Ensure evidence is correctly signed."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(self.evidence)
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(self.evidence, evidence.content)
+        self.assertEqual(self.expected_digest, evidence.digest)
+
+    def test_evidence_no_sign(self):
+        """Ensure evidence is not signed when `sign=False`."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(self.evidence, sign=False)
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(self.evidence, evidence.content)
+        self.assertEqual(None, evidence.digest)
+        self.assertEqual(None, evidence.signature)
+
+    def test_none_evidence_no_sign(self):
+        """Ensure `None` evidence is not signed."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(None)
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(None, evidence.content)
+        self.assertEqual(None, evidence.digest)
+        self.assertEqual(None, evidence.signature)
+
+    def test_signed_evidence_verify_success(self):
+        """Ensure valid, signed evidence can be verified."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(self.evidence)
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(self.evidence, evidence.content)
+        self.assertEqual(self.expected_digest, evidence.digest)
+        self.assertTrue(evidence.is_signed(self.mock_locker))
+        self.assertTrue(evidence.verify_signature(self.mock_locker))
+
+    def test_none_evidence_verify_success(self):
+        """Ensure `None` evidence can be verified."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(None)
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(None, evidence.digest)
+        self.assertEqual(None, evidence.signature)
+        self.assertTrue(evidence.is_signed(self.mock_locker))
+        self.assertTrue(evidence.verify_signature(self.mock_locker))
+
+    def test_unsigned_evidence_verify_success(self):
+        """Ensure unsigned evidence can be verified."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(self.evidence, sign=False)
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(None, evidence.digest)
+        self.assertEqual(None, evidence.signature)
+        self.assertTrue(evidence.is_signed(self.mock_locker))
+        self.assertTrue(evidence.verify_signature(self.mock_locker))
+
+    def test_tampered_evidence_verify_failure(self):
+        """Ensure invalid, signed evidence can not be verified."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(self.evidence)
+        evidence._content += 'foo'  # Tamper with evidence.
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(self.evidence + 'foo', evidence.content)
+        self.assertEqual(self.expected_digest, evidence.digest)
+        self.assertTrue(evidence.is_signed(self.mock_locker))
+        self.assertFalse(evidence.verify_signature(self.mock_locker))
+
+    def test_unknown_signed_evidence_verify_failure(self):
+        """Ensure evidence cannot be verified if the public key is unknown."""
+        evidence = RawEvidence(
+            'evidence.txt', 'test', agent=self.unknown_agent
+        )
+        evidence.set_content(self.evidence)
+
+        self.assertEqual(self.unknown_agent, evidence.agent)
+        self.assertEqual(self.evidence, evidence.content)
+        self.assertEqual(self.expected_digest, evidence.digest)
+        self.assertTrue(evidence.is_signed(self.mock_locker))
+        self.assertFalse(evidence.verify_signature(self.mock_locker))
+
+    def test_signed_evidence_verify_failure_missing_public_keys(self):
+        """Ensure evidence cannot be verified if public keys are missing."""
+        evidence = RawEvidence('evidence.txt', 'test', agent=self.agent)
+        evidence.set_content(self.evidence)
+
+        self.assertEqual(self.agent, evidence.agent)
+        self.assertEqual(self.evidence, evidence.content)
+        self.assertEqual(self.expected_digest, evidence.digest)
+        self.assertTrue(evidence.is_signed(self.mock_locker))
+        self.assertFalse(evidence.verify_signature(self.mock_empty_locker))

--- a/test/t_compliance/t_locker/test_locker.py
+++ b/test/t_compliance/t_locker/test_locker.py
@@ -80,6 +80,7 @@ class LockerTest(unittest.TestCase):
         git_mock.clone_from.assert_called_with(
             url,
             str(PurePath(tempfile.gettempdir(), 'locker-demo.git')),
+            single_branch=True,
             branch='master'
         )
 


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)

## What
All fetchers can be executed in "agent" mode. Agents will cryptographically sign
any evidence they fetch. The agent name, evidence digest and signature can be
found in the `index.json` metadata file.

Signed evidence can be used in checks. It is automatically verified when it's
loaded from the locker. However, the public key used to verify the evidence must
be made available in the locker under `raw/auditree/agent_public_keys.json`.
This evidence takes the following form:
```
  {
    "my-agent-name": "-----BEGIN PUBLIC KEY-----\n...",
    "my-other-agent-name": "-----BEGIN PUBLIC KEY-----\n...",
    ...
  }
```

We recommend you implement an additional fetcher to pull this public key
evidence into the locker and ensure it's kept up-to-date.

To configure an agent, add the following to your main configuration::
```
  {
    "agent_name": "my-agent-name",
    "agent_private_key": "/path/to/key.pem",
    ...
  }
```

Each agent must have a unique name. By default, any evidence created by an agent
will be stored under the corresponding agent directory (e.g.
``agents/my-agent-name/raw/system/uptime.txt``). These agents may not be used
for executing checks. You can set ``"use_agent_dir": false`` to suppress this
behavior.

## Why

We want to execute commands locally (on an agent), retrieve the output and store
it as evidence. This is for auditing purposes, for example, we would like to
show that a local filesystem has been encrypted.

It's important for us that all evidence can be verified; we want to be able to
prove it was actually fetched from a specific server. Therefore any agent
evidence we store must be signed by the server that fetched it.

Note, the evidence signing implementation allows all evidence types to be
signed, not just the output of commands executed locally.

## How
- Adds `fetchLocalCommands` helper to `ComplianceFetcher` class for executing
  commands locally.
- Adds new `ComplianceAgent` class for managing agents, signing and
  verification.
- Updates `_BaseEvidence` class to support evidence signing and verification.

## Test
Tested locally. Also includes additional unit tests.

## Context
- https://github.com/ComplianceAsCode/auditree-framework/issues/130