### PR TITLE
Fix python publish/deploy GH action

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo.
-*       @alfinkel @drsm79 @cletomartin @mattwhite
+*       @alfinkel @drsm79 @cletomartin @mattwhite @smithsz

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.7'
     - name: Install dependencies
       run: |
         make develop

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.22.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.22.1)
+
+- [FIXED] Set Python version to 3.7 in publish/deploy GH action to match other actions.
+
 # [1.22.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.22.0)
 
 - [ADDED] Agent mode for storing cryptographically signed evidence.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.22.0'
+__version__ = '1.22.1'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Fix python publish/deploy GH action.

## Why

Originally set to Python version 3.* it was not in sync with the other GH actions where we pinned the Python version to 3.7.  Now with latest Python at 3.10.2, a unit test failed during deploy.

## How

update the python-publish.yml setting Python version to 3.7.

## Test

We shall see...

## Context

N/A
