### PR TITLE
Implement extra lockers.

### DIFF
--- a/compliance/check.py
+++ b/compliance/check.py
@@ -295,7 +295,9 @@ class ComplianceCheck(unittest.TestCase):
         """
         evidence = self.locker.get_evidence(evidence_path, True, evidence_dt)
         self.add_evidence_metadata(
-            evidence_path, evidence_dt, getattr(evidence, 'locker', None)
+            evidence_path,
+            evidence_dt=evidence_dt,
+            evidence_locker=evidence.locker
         )
         return evidence
 

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -352,12 +352,8 @@ class RawEvidence(_BaseEvidence):
         return format_json(data)
 
     def _partition(self, data, key):
-        idx = 0
-        for field in self.part_fields:
-            data = list(
-                filter(lambda e: parse_dot_key(e, field) == key[idx], data)
-            )
-            idx += 1
+        for idx, field in enumerate(self.part_fields):
+            data = [d for d in data if parse_dot_key(d, field) == key[idx]]
         return data
 
 

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -70,6 +70,7 @@ class _BaseEvidence(object):
         self.category = category
         self.ttl = ttl
         self.description = description
+        self.locker = None
         self._agent = kwargs.get('agent') or ComplianceAgent()
         if self._agent.name and self.description:
             self.description = f'{self._agent.name}: {self.description}'
@@ -100,6 +101,7 @@ class _BaseEvidence(object):
             agent=evidence.agent,
             **kwargs
         )
+        new_evidence.locker = evidence.locker
         new_evidence.set_digest(evidence.digest)
         new_evidence.set_signature(evidence.signature)
         new_evidence.set_content(
@@ -605,29 +607,30 @@ class evidences(object):  # noqa: N801
     def __enter__(self):
         """Perform check evidences pre-processing."""
         evidence = {}
-        evidence_list = []
+        rtval_dict = True
         if isinstance(self.from_evidences, list):
             for from_evidence in self.from_evidences:
                 path = from_evidence
                 if isinstance(from_evidence, LazyLoader):
                     # preserve original path to be used as key of evidence dict
                     path = from_evidence.path
-                ev = self._get_evidence(from_evidence)
-                evidence[path] = ev
-                evidence_list.append(ev.path)
+                evidence[path] = self._get_evidence(from_evidence)
         elif isinstance(self.from_evidences, dict):
             for evidence_name, from_evidence in self.from_evidences.items():
                 evidence[evidence_name] = self._get_evidence(from_evidence)
-                evidence_list.append(evidence[evidence_name].path)
         else:
-            evidence = self._get_evidence(self.from_evidences)
-            evidence_list.append(evidence.path)
-        if hasattr(self, 'check'):
-            for ev_path in evidence_list:
-                self.check.add_evidence_metadata(ev_path)
+            rtval_dict = False
+            evidence['evidence'] = self._get_evidence(self.from_evidences)
         if not evidence:
             raise EvidenceNotFoundError('No evidence found!')
-        return evidence
+        if hasattr(self, 'check'):
+            for ev in evidence.values():
+                self.check.add_evidence_metadata(
+                    ev.path, evidence_locker=ev.locker
+                )
+        if rtval_dict:
+            return evidence
+        return next(iter(evidence.values()))
 
     def __exit__(self, typ, val, traceback):
         """Perform check evidences post-processing."""
@@ -1017,5 +1020,7 @@ def _evidence_wrapper(self, from_evidences, func):
             ev = fe.ev_class.from_evidence(ev)
         evidences.append(ev)
     for evidence in evidences:
-        self.add_evidence_metadata(evidence.path)
+        self.add_evidence_metadata(
+            evidence.path, evidence_locker=evidence.locker
+        )
     return func(self, *evidences)

--- a/compliance/runners.py
+++ b/compliance/runners.py
@@ -119,7 +119,8 @@ class _BaseRunner(object):
                 name=dirname,
                 ttl_tolerance=ttl_tolerance,
                 gitconfig=gitconfig,
-                branch=self.config.get('locker.branch')
+                branch=self.config.get('locker.branch'),
+                local_path=self.config.get('locker.local_path')
             )
         repo_url = self.config.get('locker.repo_url')
         if repo_url is None:
@@ -131,7 +132,8 @@ class _BaseRunner(object):
             do_push=True if mode == 'full-remote' else False,
             ttl_tolerance=ttl_tolerance,
             gitconfig=gitconfig,
-            branch=self.config.get('locker.branch')
+            branch=self.config.get('locker.branch'),
+            local_path=self.config.get('locker.local_path')
         )
 
 

--- a/doc-source/quick-start.rst
+++ b/doc-source/quick-start.rst
@@ -154,6 +154,28 @@ remote locker::
 
   $ compliance --check demo.arboretum.accred,demo.custom.accred --evidence full-remote -C auditree_demo.json
 
+You can configure multiple remote lockers using the ``extra``
+configuration. This is useful if you're running lots of Auditree agents and
+storing evidence in multiple lockers. It allows you to check all evidence
+centrally, for example::
+
+  "locker": {
+    "repo_url": "https://github.com/foo/evidence-locker",
+    "extra": [
+      {
+        "repo_url": "https://github.com/foo/evidence-locker-bar"
+      },
+      {
+        "repo_url": "https://github.com/foo/evidence-locker-baz"
+      }
+    ]
+  }
+
+The ``extra`` lockers are only used when **checking** evidence. If evidence is
+not found in the primary locker then Auditree will look in any ``extra`` lockers
+that have been configured. Only the primary locker can be used to store new
+evidence.
+
 Notifications
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
Allows multiple lockers to be configured.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)

## What

You can configure multiple remote lockers using the ``extra`` configuration, for example:

```
  "locker": {
    "repo_url": "https://github.com/foo/evidence-locker",
    "extra": [
      {
        "repo_url": "https://github.com/foo/evidence-locker-bar"
      },
      {
        "repo_url": "https://github.com/foo/evidence-locker-baz"
      }
    ]
  }
```

The ``extra`` lockers are only used when **checking** evidence. If evidence is not found in the primary locker then Auditree will look in any ``extra`` lockers that have been configured. Only the primary locker can be used to store new evidence.

## Why

This is useful if you're running lots of Auditree agents and storing evidence in multiple lockers. It allows you to check all evidence centrally.

## Test

Tested locally.

## Context

Closes https://github.com/ComplianceAsCode/auditree-framework/issues/134.
