### PR TITLE
Publish version 1.23.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# [1.23.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.23.0)
+
+- [ADDED] Locker shallow clone depth configuration.
+- [ADDED] Multiple remote lockers for fetching evidence.
+- [FIXED] Correctly acquire the locker lock when iterating repository commits.
+- [FIXED] Raise the `EvidenceNotFoundError` exception for missing evidence.
+
 # [1.22.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.22.1)
 
 - [FIXED] Set Python version to 3.7 in publish/deploy GH action to match other actions.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.22.1'
+__version__ = '1.23.0'


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)

## What

Publish version `1.23.0`.

Changes:
- [ADDED] Locker shallow clone depth configuration.
- [ADDED] Multiple remote lockers for fetching evidence.
- [FIXED] Correctly acquire the locker lock when iterating repository commits.
- [FIXED] Raise the `EvidenceNotFoundError` exception for missing evidence.