### PR TITLE
Update pre-commit dependencies

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       working-directory: ./source
       run: |

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         make develop

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         make develop

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,20 @@
 repos:
--   repo: https://github.com/pre-commit/mirrors-yapf
-    rev: v0.31.0
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      -   id: trailing-whitespace
+      -   id: check-yaml
+      -   id: fix-encoding-pragma
+          args: ["--remove"]  # Not needed on python3
+-   repo: https://github.com/google/yapf
+    rev: v0.32.0
     hooks:
     -   id: yapf
         args: [--in-place, --parallel, --recursive, --style, .yapf-config]
         files: "^(compliance|test)"
         stages: [commit]
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/PyCQA/flake8
+    rev: 5.0.4
     hooks:
     -   id: flake8
         args: [
@@ -35,7 +42,7 @@ repos:
         files: "^(compliance|test)"
         stages: [commit]
 -   repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
+    rev: 1.7.4
     hooks:
     -   id: bandit
         args: [--recursive]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+# [UNRELEASED](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/UNRELEASED)
+
+- [FIXED] Update pre-commit dependencies.
+- [CHANGED] Use python 3.8 in GitHub Actions as newer flake8 does not support less than that.
+- [CHANGED] Dot not update pre-commit hooks during "make develop"
+- [ADDED] Add basic pre-commit hooks.
+
 # [1.23.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.23.0)
 
 - [ADDED] Locker shallow clone depth configuration.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team ([Al Finkelstein](https://github.com/alfinkel) 
+reported by contacting the project team ([Al Finkelstein](https://github.com/alfinkel)
 or [Simon Metson](https://github.com/drsm79)). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ DOC_TARGET?=doc
 develop:
 	pip install -q -e .[dev] --upgrade --upgrade-strategy eager
 	pre-commit install
+
+update-pre-commit:
 	pre-commit autoupdate
 
 install:

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,4 +13,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = '1.23.0'
+__version__ = '1.23.1'

--- a/compliance/agent.py
+++ b/compliance/agent.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/config.py
+++ b/compliance/config.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/controls.py
+++ b/compliance/controls.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/evidence.py
+++ b/compliance/evidence.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2021, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/fetch.py
+++ b/compliance/fetch.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2021, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/fix.py
+++ b/compliance/fix.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/locker.py
+++ b/compliance/locker.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2021, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/notify.py
+++ b/compliance/notify.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/report.py
+++ b/compliance/report.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/runners.py
+++ b/compliance/runners.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2021, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/scripts/__init__.py
+++ b/compliance/scripts/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/scripts/compliance_cli.py
+++ b/compliance/scripts/compliance_cli.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/__init__.py
+++ b/compliance/utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/credentials.py
+++ b/compliance/utils/credentials.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/data_parse.py
+++ b/compliance/utils/data_parse.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/exceptions.py
+++ b/compliance/utils/exceptions.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2021, 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/http.py
+++ b/compliance/utils/http.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/path.py
+++ b/compliance/utils/path.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/services/__init__.py
+++ b/compliance/utils/services/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/services/github.py
+++ b/compliance/utils/services/github.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/services/pagerduty.py
+++ b/compliance/utils/services/pagerduty.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/compliance/utils/test.py
+++ b/compliance/utils/test.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/__init__.py
+++ b/demo/demo_examples/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/checks/__init__.py
+++ b/demo/demo_examples/checks/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/checks/test_common.py
+++ b/demo/demo_examples/checks/test_common.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/checks/test_image_content.py
+++ b/demo/demo_examples/checks/test_image_content.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/checks/test_world_clock.py
+++ b/demo/demo_examples/checks/test_world_clock.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/evidences/__init__.py
+++ b/demo/demo_examples/evidences/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/fetchers/__init__.py
+++ b/demo/demo_examples/fetchers/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/fetchers/fetch_auditree_logo.py
+++ b/demo/demo_examples/fetchers/fetch_auditree_logo.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/fetchers/fetch_common.py
+++ b/demo/demo_examples/fetchers/fetch_common.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/demo/demo_examples/fetchers/fetch_world_clock.py
+++ b/demo/demo_examples/fetchers/fetch_world_clock.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/doc-source/conf.py
+++ b/doc-source/conf.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 
 import os
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/__init__.py
+++ b/test/t_compliance/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_agent/__init__.py
+++ b/test/t_compliance/t_agent/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_agent/test_agent.py
+++ b/test/t_compliance/t_agent/test_agent.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_check/__init__.py
+++ b/test/t_compliance/t_check/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_check/test_base_check.py
+++ b/test/t_compliance/t_check/test_base_check.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_controls/__init__.py
+++ b/test/t_compliance/t_controls/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_controls/test_controls.py
+++ b/test/t_compliance/t_controls/test_controls.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_evidence/__init__.py
+++ b/test/t_compliance/t_evidence/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_evidence/test_partitioning.py
+++ b/test/t_compliance/t_evidence/test_partitioning.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_evidence/test_signing.py
+++ b/test/t_compliance/t_evidence/test_signing.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2022 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_fetch/__init__.py
+++ b/test/t_compliance/t_fetch/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_fetch/test_base_fetcher.py
+++ b/test/t_compliance/t_fetch/test_base_fetcher.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_fix/__init__.py
+++ b/test/t_compliance/t_fix/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_fix/test_fixer.py
+++ b/test/t_compliance/t_fix/test_fixer.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_locker/__init__.py
+++ b/test/t_compliance/t_locker/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_locker/test_locker.py
+++ b/test/t_compliance/t_locker/test_locker.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/__init__.py
+++ b/test/t_compliance/t_notify/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_base_notify.py
+++ b/test/t_compliance/t_notify/test_base_notify.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_fd_notifier.py
+++ b/test/t_compliance/t_notify/test_fd_notifier.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_findings_notifier.py
+++ b/test/t_compliance/t_notify/test_findings_notifier.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_gh_notifier.py
+++ b/test/t_compliance/t_notify/test_gh_notifier.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_locker_notifier.py
+++ b/test/t_compliance/t_notify/test_locker_notifier.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_md_notify.py
+++ b/test/t_compliance/t_notify/test_md_notify.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_pd_notify.py
+++ b/test/t_compliance/t_notify/test_pd_notify.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_notify/test_slack_notifier.py
+++ b/test/t_compliance/t_notify/test_slack_notifier.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_report/__init__.py
+++ b/test/t_compliance/t_report/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_report/test_report.py
+++ b/test/t_compliance/t_report/test_report.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_utils/__init__.py
+++ b/test/t_compliance/t_utils/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_utils/test_data_parse.py
+++ b/test/t_compliance/t_utils/test_data_parse.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/t_compliance/t_workflow/__init__.py
+++ b/test/t_compliance/t_workflow/__init__.py
@@ -1,4 +1,3 @@
-# -*- mode:python; coding:utf-8 -*-
 # Copyright (c) 2020 IBM Corp. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Some pre-commit dependencies are too old and URLs are not valid any more.

- Note that `flake8` 6.0.0 is not used yet as many of the additional_dependencies are not ready to use it yet.
- Bump python version 3.8 in GitHub Actions so flake8 5.x can be used.
- Add a few basic pre-commit hooks.

## Why

Need to keep the tools updated.

## How

Bump versions and fix URLs.

## Test

Locally tested.
