### PR TITLE
Fix notifier counts for single checks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [1.24.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.24.1)
+
+- [FIXED] Number of errors/warnings shown correctly for single checks.
+
 # [1.24.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.24.0)
 
 - [FIXED] Update pre-commit dependencies.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = "1.24.0"
+__version__ = "1.24.1"

--- a/compliance/notify.py
+++ b/compliance/notify.py
@@ -66,12 +66,10 @@ class _BaseNotifier(object):
             test_obj = test_desc["test"].test
             method_name = parse_test_id(test_id)["method"]
 
-            msg_method = "get_notification_message"
-            if len(test_obj.tests) > 1:
-                candidate = method_name.replace("test_", "msg_", 1)
-                if hasattr(test_obj, candidate):
-                    msg_method = candidate
-
+            msg_method = "get_notification_message"  # default notification method
+            candidate = method_name.replace("test_", "msg_", 1)
+            if hasattr(test_obj, candidate):
+                msg_method = candidate
             # set body to None if the notification function hasn't been
             # defined or if it returns None.
             # use a predefined error message for error status.
@@ -96,19 +94,11 @@ class _BaseNotifier(object):
             if msg and "subtitle" in msg and msg["subtitle"]:
                 title += f' - {msg["subtitle"]}'
 
-            failure_count = 0
-            if msg and test_obj.failures:
-                failure_count = test_obj.failures_count()
-
-            warning_count = 0
-            if msg and test_obj.warnings:
-                warning_count = test_obj.warnings_count()
-
             msg = {
                 "title": title,
                 "body": body,
-                "failure_count": failure_count,
-                "warning_count": warning_count,
+                "failure_count": test_obj.failures_count(),
+                "warning_count": test_obj.warnings_count(),
             }
             yield test_id, test_desc, msg
 

--- a/demo/demo_examples/checks/test_github.py
+++ b/demo/demo_examples/checks/test_github.py
@@ -100,7 +100,7 @@ class GitHubOrgs(ComplianceCheck):
         if not members:
             self.add_failures(org, "There is nobody!")
         elif len(members) < 5:
-            self.add_warnings(org, "There are people int there, but less than 5!")
+            self.add_warnings(org, "There are people in there, but less than 5!")
 
     def get_reports(self):
         """Return GitHub report name."""

--- a/doc-source/notifiers.rst
+++ b/doc-source/notifiers.rst
@@ -14,8 +14,8 @@ system is that each ``test_`` can generate a short notification that has the
 following components:
 
     **NOTE:** When configuring notifiers, you should be aware of the
-    possibilitythat notifications may contain sensitive information that can be
-    sent to less trusted stores like Slack or public git issue trackers.  So be
+    possibility that notifications may contain sensitive information that can be
+    sent to less trusted stores like Slack or public git issue trackers. So be
     mindful of check notification content as well as the nature of the forum
     you intend to send these notifications to.
 

--- a/test/t_compliance/t_controls/test_controls.py
+++ b/test/t_compliance/t_controls/test_controls.py
@@ -57,7 +57,7 @@ class ControlDescriptorTest(unittest.TestCase):
         """Ensure that control content cannot be changed through as_dict."""
         with self.assertRaises(AttributeError) as ar:
             self.cd.as_dict = {"foo": "bar"}
-        self.assertEqual(str(ar.exception), "can't set attribute")
+        self.assertTrue(str(ar.exception).startswith("can't set attribute"))
         controls_copy = self.cd.as_dict
         self.assertEqual(controls_copy, self.cd.as_dict)
         controls_copy.update({"foo": "bar"})


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

For those checks that only have one check_ method, the current code didn't show up correctly the number of errors/warnings correctly.

## Why

It wasn't working as expected.

## How

Do not make a special case when calculating the message structure.

## Test

Passing unit tests and update demo to ensure that this also happens.

