### PR TITLE
Remove the need of a --creds-path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
-# [1.24.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.24.1)
+# [1.25.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.25.0)
 
+- [ADDED] Documentation on how to use it with 1Password CLI.
+- [CHANGED] "--creds-path" does not default to "~/.credentials".
 - [FIXED] Number of errors/warnings shown correctly for single checks.
 
 # [1.24.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v1.24.0)

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = "1.24.1"
+__version__ = "1.25.0"

--- a/compliance/config.py
+++ b/compliance/config.py
@@ -68,11 +68,9 @@ class ComplianceConfig(object):
     @property
     def creds(self):
         """Credentials used for locker management and running fetchers."""
-        if self.creds_path is None:
-            raise ValueError("Path to credentials file not provided")
-
-        if self._creds is None:
-            self._creds = Config(self.creds_path)
+        if not self._creds:
+            path = None if self.creds_path is None else str(self.creds_path)
+            self._creds = Config(path)
         return self._creds
 
     @property

--- a/compliance/runners.py
+++ b/compliance/runners.py
@@ -91,11 +91,15 @@ class _BaseRunner(object):
                 yield test
 
     def _load_compliance_config(self):
-        creds_path = Path(self.opts.creds_path).expanduser()
-        if not creds_path.is_file():
-            raise ValueError(f"{creds_path} file does not exist.")
         self.config = get_config()
-        self.config.creds_path = str(creds_path)
+        creds_path = None
+        if self.opts.creds_path is not None:
+            creds_path = Path(self.opts.creds_path).expanduser()
+            if not creds_path.is_file():
+                raise ValueError(
+                    f"Invalid path to credentials file '{str(creds_path)}'"
+                )
+        self.config.creds_path = creds_path
         self.config.load(self.opts.compliance_config)
 
     def _init_dirs(self):

--- a/compliance/scripts/compliance_cli.py
+++ b/compliance/scripts/compliance_cli.py
@@ -83,7 +83,7 @@ class ComplianceCLI(Command):
                 "Defaults to %(default)s."
             ),
             metavar="/path/to/creds.ini",
-            default="~/.credentials",
+            default=None,
         )
         notify_options = [k for k in get_notifiers().keys() if k != "stdout"]
         self.add_argument(

--- a/doc-source/design-principles.rst
+++ b/doc-source/design-principles.rst
@@ -750,9 +750,51 @@ levels:
 Credentials
 ~~~~~~~~~~~
 
-If you want to configure your credentials locally, the framework
-will look for a credentials file at ``~/.credentials`` by default. This
-file should be similar to this:
+There are 2 ways for providing credentials:
 
-.. include:: credentials-example.cfg
-   :literal:
+1. *Local file*: if you want to configure your credentials in a local file,
+   you will have to provide the the framework using ``--creds-path`` option.
+   This file should be similar to this:
+
+   .. include:: credentials-example.cfg
+      :literal:
+
+1. *Environment variables*: each section and field of the local file can be
+   rendered as an environment variable.
+   For instance, suppose your code requires ``creds['github'].token`` or ``creds['slack'].webhook``.
+   You just need to export:
+
+   * ``GITHUB_TOKEN = XXX``
+
+   * ``MY_SERVICE_API_KEY = YYY``
+
+   This is equivalent to the credentials file::
+
+     [github]
+     token=XXX
+
+     [my_service]
+     api_key=YYY
+
+Creds with ``.env`` files and 1Password
++++++++++++++++++++++++++++++++++++++++
+
+Combining the method based on passing env vars to Auditree and `1Password CLI <https://developer.1password.com/docs/cli/>`_,
+it is possible to grab the secrets from 1Password and inject them into Auditree.
+Here it is how to do it:
+
+1. Create the following alias::
+
+     alias compliance="op run --env-file .env -- compliance"
+
+1. In your fetchers/checks project, create an ``.env`` file with the following schema::
+
+     <SECTION>_<ATTRIBUTE>="op://<VAULT>/<ITEM>/<FIELD>"
+
+   For example::
+
+     GITHUB_TOKEN="op://Private/github/token"
+     MY_SERVICE_ORG="the-org-id"
+     MY_SERVICE_API_KEY="op://Shared/my_service/api_key"
+
+1. Now running ``compliance`` will pull credentials from 1Password vaults.

--- a/doc-source/notifiers.rst
+++ b/doc-source/notifiers.rst
@@ -134,7 +134,9 @@ You can also use a Slack app token (recommended if you need to post
 messages to private channels)::
 
   [slack]
-  slack=XXX
+  token=XXX
+
+Note that you can do the same thing using env vars ``SLACK_WEBHOOK`` and ``SLACK_TOKEN``.
 
 In case you need private channels as part of the list, you have to
 specify the channel ID::


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

If --creds-path is not provided it will not default to `~/.credentials` any more. Instead, it will assume that env vars want to be used and it will try so.

Also, the documentation has been updated to reflect this and provide a way to use 1Password CLI as a credentials loader.

## Why

This will improve security and UX.

## How

- If `--creds-path` is not provided, do not fail and carry on assuming creds are in the env vars.
- If `--creds-path` is provided, then fail if it is not possible to load the file.

## Test

Manually tested.

