### PR TITLE
Enable universal newlines when executing local commands.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [2.0.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v2.0.1)
+
+- [FIXED] Enable universal newlines when executing local commands.
+
 # [2.0.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v2.0.0)
 
 - [ADDED] Documentation on how to use it with 1Password CLI.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/compliance/fetch.py
+++ b/compliance/fetch.py
@@ -150,12 +150,10 @@ class ComplianceFetcher(unittest.TestCase):
             cmd += ["-t"]
         if not cwd:
             cwd = os.path.expanduser("~")
-        stdin = str.encode("\n".join(commands) + "\n")
-        return (
-            check_output(cmd, cwd=cwd, env=env, input=stdin, timeout=timeout)
-            .decode()
-            .rstrip()
-        )
+        stdin = "\n".join(commands) + "\n"
+        return check_output(
+            cmd, cwd=cwd, env=env, input=stdin, timeout=timeout, universal_newlines=True
+        ).rstrip()
 
 
 def fetch(url, name):


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)

## What
This change enables universal newline mode during the evidence fetch. The subprocess output will be opened as text streams in universal newlines mode. All line endings will be converted to '\n' ensuring the evidence can be later verified.

## Why
Universal newline support is enabled by default in all calls that read data. This means that any non-binary evidence with a foreign newline convention cannot be verified. When the evidence is read, all line endings are converted to '\n' which changes the expected digest.

## How
Set `universal_newlines=True`.

## Test
Tested locally.

## Context
- https://github.com/ComplianceAsCode/auditree-framework/issues/155