### PR TITLE
fix: add assertEquals compatibility for Python 3.12+

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# [3.0.1](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v3.0.1)
+
+- [CHANGED] Add compatibility with assertEquals() for Python 3.12+.
+
 # [3.0.0](https://github.com/ComplianceAsCode/auditree-framework/releases/tag/v3.0.0)
 
 - [CHANGED] Remove IBM findings notifier.

--- a/compliance/__init__.py
+++ b/compliance/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 """Compliance automation package."""
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"

--- a/compliance/check.py
+++ b/compliance/check.py
@@ -248,7 +248,7 @@ class ComplianceCheck(unittest.TestCase):
         def wrapper(method):
             def check_failures():
                 method()
-                self.assertEquals(self.failures_count(), 0)
+                self.assertEqual(self.failures_count(), 0)
 
             return check_failures
 
@@ -348,3 +348,6 @@ class ComplianceCheck(unittest.TestCase):
             for info in results.values()
             if info["test"].test.__class__ == self.__class__
         ]
+
+    # keep backward compatibility so users can still use assertEquals()
+    assertEquals = unittest.TestCase.assertEqual

--- a/test/t_compliance/t_check/test_base_check.py
+++ b/test/t_compliance/t_check/test_base_check.py
@@ -212,3 +212,7 @@ class ComplianceCheckTest(unittest.TestCase):
                 }
             },
         )
+
+    def test_has_assertEquals(self):
+        """Test assertEquals is still present"""
+        self.check.assertEquals(1, 1)


### PR DESCRIPTION
- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Add assertEquals compatibility for Python 3.12+.

## Why

Looks like assertEquals() has been retired from unittest.TestCase. We use `assertEqual()` now but we will allow users to use `assertEquals()` for existing checks.

## How

Add a method to ComplianceCheck that points to `asserEqual()`.

## Test

Added unit tests and manually tested.
