### PR TITLE
Re-run store_derived_evidence fetchers

### DIFF
--- a/test/t_compliance/t_evidence/test_evidence.py
+++ b/test/t_compliance/t_evidence/test_evidence.py
@@ -1,0 +1,40 @@
+import unittest
+from unittest.mock import MagicMock, create_autospec
+
+from compliance.evidence import store_derived_evidence
+from compliance.locker import Locker
+from compliance.utils.exceptions import DependencyUnavailableError, StaleEvidenceError
+
+
+class TestEvidence(unittest.TestCase):
+
+    def test_store_derived_evidence_adds_to_rerun(self):
+        """
+        Ensure that when running a fetcher that stores derived evidence
+        that it is re-run if one of the dependant evidence is not available.
+        """
+        self.locker = create_autospec(Locker)
+        self.locker.dependency_rerun = []
+        self.locker.validate.side_effect = [False, StaleEvidenceError]
+        self.locker.repo_url = "https://my.locker.url"
+        self.locker.get_evidence_metadata = MagicMock()
+        self.locker.get_evidence_metadata.return_value = None
+        self.locker.get_evidence.side_effect = StaleEvidenceError
+
+        with self.assertRaises(DependencyUnavailableError):
+            self.fetch_some_derived_evidence()
+
+        self.assertEquals(1, len(self.locker.dependency_rerun))
+        f = self.fetch_some_derived_evidence
+        self.assertDictEqual(
+            self.locker.dependency_rerun[0],
+            {
+                "module": f.__module__,
+                "class": self.__class__.__name__,
+                "method": f.__name__,
+            },
+        )
+
+    @store_derived_evidence(["raw/cos/cos_bucket_metadata.json"], target="cos/bar.json")
+    def fetch_some_derived_evidence(self, cos_metadata):
+        return "{}"


### PR DESCRIPTION


- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](../blob/master/DCO1.1.txt)


## What

Ensure store_derived_evidence fetchers are re-run if dependent evidence is not yet available, this is achieved by get_evidence_dependency, rather than get_evidence_by_path.

## Why

When running fetchers that store derived evidence, they often rely on evidence from previous fetchers, however if this evidence is not available the fetcher fails and is not automatically re-run because the store_derived_evidence function does not treat source evidence as dependency that can be re-run.

## How
- Replace `get_evidence_by_path` call to `get_evidence_dependency` call in the decorator wrapper function.

## Test

- Validated the current tests pass
- Validated the evidence is re-run

## Context

